### PR TITLE
Craft 4 - Allow usage of current CP language for alt text generation

### DIFF
--- a/src/AltTextGenerator.php
+++ b/src/AltTextGenerator.php
@@ -3,33 +3,41 @@
 namespace dispositiontools\craftalttextgenerator;
 
 use Craft;
-use craft\base\Element;
+use yii\base\Event;
+use yii\log\Logger;
 use craft\base\Model;
+use Psr\Log\LogLevel;
 use craft\base\Plugin;
-use craft\elements\Asset;
-use craft\events\ModelEvent;
-use craft\events\PluginEvent;
-use craft\events\RegisterComponentTypesEvent;
-use craft\events\RegisterElementActionsEvent;
-use craft\events\RegisterUrlRulesEvent;
-use craft\events\RegisterUserPermissionsEvent;
+use craft\base\Element;
+use craft\helpers\Html;
 use craft\helpers\Queue;
-use craft\services\Dashboard;
+use craft\elements\Asset;
+use craft\web\UrlManager;
 use craft\services\Fields;
 use craft\services\Plugins;
-use craft\services\UserPermissions;
+use craft\events\ModelEvent;
+use craft\log\MonologTarget;
+use craft\events\PluginEvent;
+use craft\services\Dashboard;
 use craft\services\Utilities;
-use craft\web\UrlManager;
-use dispositiontools\craftalttextgenerator\elements\actions\GenerateAltText;
-use dispositiontools\craftalttextgenerator\fields\AltTextGenerator as AltTextGeneratorAlias;
-use dispositiontools\craftalttextgenerator\jobs\RequestAltText as RequestAltTextJob;
+use craft\events\DefineHtmlEvent;
+use craft\services\UserPermissions;
+use Monolog\Formatter\LineFormatter;
+use craft\events\RegisterUrlRulesEvent;
+use craft\events\RegisterComponentTypesEvent;
+use craft\events\RegisterElementActionsEvent;
+
+
+use craft\events\RegisterUserPermissionsEvent;
 use dispositiontools\craftalttextgenerator\models\Settings;
+
 use dispositiontools\craftalttextgenerator\services\AltTextAiApi;
-use dispositiontools\craftalttextgenerator\utilities\AltTextGeneratorUtility;
-
-
 use dispositiontools\craftalttextgenerator\widgets\ImageAltTextStats;
-use yii\base\Event;
+use dispositiontools\craftalttextgenerator\elements\actions\GenerateAltText;
+use dispositiontools\craftalttextgenerator\utilities\AltTextGeneratorUtility;
+use dispositiontools\craftalttextgenerator\jobs\RequestAltText as RequestAltTextJob;
+use dispositiontools\craftalttextgenerator\elements\actions\GenerateAltTextAssetAction;
+use dispositiontools\craftalttextgenerator\fields\AltTextGenerator as AltTextGeneratorAlias;
 
 /**
  * Alt text Generator plugin
@@ -41,193 +49,270 @@ use yii\base\Event;
  * @license https://craftcms.github.io/license/ Craft License
  * @property-read AltTextAiApi $altTextAiApi
  */
-class AltTextGenerator extends Plugin
-{
-    public string $schemaVersion = '1.0.0';
-    public bool $hasCpSettings = true;
-    public bool $hasCpSection = true;
+class AltTextGenerator extends Plugin {
+	public string $schemaVersion = '1.0.0';
+	public bool $hasCpSettings = true;
+	public bool $hasCpSection = true;
 
 
-    public static function config(): array
-    {
-        return [
-            'components' => ['altTextAiApi' => AltTextAiApi::class],
-        ];
-    }
+	public static function config(): array {
+		return [
+			'components' => ['altTextAiApi' => AltTextAiApi::class],
+		];
+	}
 
-    public function init(): void
-    {
-        parent::init();
+	public function init(): void {
+		parent::init();
 
-        // Defer most setup tasks until Craft is fully initialized
-        Craft::$app->onInit(function() {
-            $this->attachEventHandlers();
-            // ...
-        });
-    }
+		// Defer most setup tasks until Craft is fully initialized
+		Craft::$app->onInit(function () {
+			$this->attachEventHandlers();
+			// ...
+		});
+	}
 
-    protected function createSettingsModel(): ?Model
-    {
-        return Craft::createObject(Settings::class);
-    }
+	protected function createSettingsModel(): ?Model {
+		return Craft::createObject(Settings::class);
+	}
 
-    protected function settingsHtml(): ?string
-    {
-        return Craft::$app->view->renderTemplate('alt-text-generator/_settings.twig', [
-            'plugin' => $this,
-            'settings' => $this->getSettings(),
-        ]);
-    }
+	protected function settingsHtml(): ?string {
+		return Craft::$app->view->renderTemplate('alt-text-generator/_settings.twig', [
+			'plugin' => $this,
+			'settings' => $this->getSettings(),
+		]);
+	}
 
-    private function attachEventHandlers(): void
-    {
-        // Register event handlers here ...
-        // (see https://craftcms.com/docs/4.x/extend/events.html to get started)
-            
-        /*
+	private function attachEventHandlers(): void {
+		// Register event handlers here ...
+		// (see https://craftcms.com/docs/4.x/extend/events.html to get started)
+
+		/*
         Event::on(Fields::class, Fields::EVENT_REGISTER_FIELD_TYPES, function (RegisterComponentTypesEvent $event) {
             $event->types[] = AltTextGeneratorAlias::class;
         });
         */
-        
-        $settings = $this->getSettings();
+
+		$settings = $this->getSettings();
 
 
-        Event::on(Utilities::class, Utilities::EVENT_REGISTER_UTILITY_TYPES, function(RegisterComponentTypesEvent $event) {
-            $event->types[] = AltTextGeneratorUtility::class;
-        });
- 
-        if (Craft::$app->user->checkPermission('altTextGeneratorAssetAction')) {
-            Event::on(
-                    Asset::class,
-                    Element::EVENT_REGISTER_ACTIONS,
-                    function(RegisterElementActionsEvent $event) {
-                        $event->actions[] = GenerateAltText::class;
+		Event::on(Utilities::class, Utilities::EVENT_REGISTER_UTILITY_TYPES, function (RegisterComponentTypesEvent $event) {
+			$event->types[] = AltTextGeneratorUtility::class;
+		});
+
+		if (Craft::$app->user->checkPermission('altTextGeneratorAssetAction')) {
+			Event::on(
+				Asset::class,
+				Element::EVENT_REGISTER_ACTIONS,
+				function (RegisterElementActionsEvent $event) {
+					$event->actions[] = GenerateAltText::class;
+				}
+			);
+
+			Event::on(
+				Asset::class,
+				Element::EVENT_DEFINE_ADDITIONAL_BUTTONS,
+				function (DefineHtmlEvent $event) {
+					$this->appendAssetEditPageButtons($event);
+				}
+			);
+		}
+
+
+		Event::on(
+			UserPermissions::class,
+			UserPermissions::EVENT_REGISTER_PERMISSIONS,
+			function (RegisterUserPermissionsEvent $event) {
+				$event->permissions[] = [
+					'heading' => 'Alt Text Generator',
+					'permissions' => [
+
+						'altTextGeneratorWidgetStats' => [
+							'label' => 'Stats widget',
+						],
+						'altTextGeneratorViewDashboard' => [
+							'label' => 'View dashboard',
+							'nested' => [
+								'altTextGeneratorSyncAltText' => [
+									'label' => 'Sync generated alt text with asset',
+								],
+								'altTextGeneratorHumanReview' => [
+									'label' => 'Request human review of AI generated alt text',
+								],
+								'altTextGeneratorDelete' => [
+									'label' => 'Delete record',
+								],
+								'altTextGeneratorRequestRefresh' => [
+									'label' => 'Refresh image data from altText.ai',
+								],
+							],
+						],
+						'altTextGeneratorViewHistory' => [
+							'label' => 'View history',
+						],
+
+						'altTextGeneratorAssetAction' => [
+							'label' => 'Queue alt text generation with asset actions',
+						],
+					],
+				];
+			}
+		);
+
+
+		// Create event to send asset to have alt text generated if that setting is set to true
+		if ($settings->generateOnSave === true) {
+			Event::on(
+				Asset::class,
+				Asset::EVENT_AFTER_PROPAGATE,
+				function (ModelEvent $event) {
+					if (($event->sender->enabled && $event->sender->getEnabledForSite()) &&
+						$event->sender->firstSave && $event->sender->alt == ""
+					) {
+						$currentUser = Craft::$app->getUser()->getIdentity();
+						if ($currentUser) {
+							$currentUserId = $currentUser->id;
+						} else {
+							$currentUserId = null;
+						}
+
+						Queue::push(new RequestAltTextJob([
+							"assetId" => $event->sender->id,
+							"requestUserId" => $currentUserId,
+							"actionType" => "On save",
+						]));
+					}
+				}
+			);
+		} // if settings generateOnSave is true
+
+
+
+		// Register the control panel routes.
+		Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES, function (RegisterUrlRulesEvent $event) {
+			$event->rules['alt-text-generator'] = 'alt-text-generator/cp/dashboard';
+			$event->rules['alt-text-generator/history'] = 'alt-text-generator/cp/history';
+			$event->rules['alt-text-generator/errors'] = 'alt-text-generator/cp/errors';
+		});
+
+		// register event for when saving an asset
+
+
+
+
+		// Generate the encryption key that is unique to this installation.
+		Event::on(Plugins::class, Plugins::EVENT_AFTER_INSTALL_PLUGIN, function (PluginEvent $event) {
+			if ($event->plugin === $this) {
+				$initialSettings = ['securityCode' => Craft::$app->getSecurity()->generateRandomString(16)];
+				Craft::$app->getPlugins()->savePluginSettings($this, $initialSettings);
+			}
+		});
+
+		Event::on(Dashboard::class, Dashboard::EVENT_REGISTER_WIDGET_TYPES, function (RegisterComponentTypesEvent $event) {
+			if (Craft::$app->user->checkPermission('altTextGeneratorWidgetStats')) {
+				$event->types[] = ImageAltTextStats::class;
+			}
+		});
+
+		$this->_registerLogTarget();
+	}
+
+
+	public function getCpNavItem(): ?array {
+		$numberOfItemsToReview = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextsToReview();
+
+
+		$item = parent::getCpNavItem();
+		$item['badgeCount'] = $numberOfItemsToReview;
+		$showNav = false;
+		if (Craft::$app->user->checkPermission('altTextGeneratorViewDashboard')) {
+			$item['subnav']['review'] = ['label' => 'Review', 'url' => 'alt-text-generator'];
+			$showNav = true;
+		}
+		if (Craft::$app->user->checkPermission('altTextGeneratorViewHistory')) {
+			$item['subnav']['history'] = ['label' => 'History', 'url' => 'alt-text-generator/history'];
+			$showNav = true;
+		}
+		if (Craft::$app->user->checkPermission('altTextGeneratorViewHistory')) {
+			$item['subnav']['errors'] = ['label' => 'Errors', 'url' => 'alt-text-generator/errors'];
+			$showNav = true;
+		}
+		if ($showNav == true) {
+			return $item;
+		} else {
+			return null;
+		}
+	}
+
+
+
+	/**
+	 * Logs an informational message to our custom log target.
+	 */
+	public static function info(string $message): void {
+		Craft::info($message, 'alt-text-generator');
+	}
+
+	/**
+	 * Logs an error message to our custom log target.
+	 */
+	public static function error(string $message): void {
+		Craft::error($message, 'alt-text-generator');
+	}
+
+	/**
+	 * Registers a custom log target, keeping the format as simple as possible.
+	 */
+
+	private function _registerLogTarget(): void {
+		Craft::getLogger()->dispatcher->targets[] = new MonologTarget([
+			'name' => 'alt-text-generator',
+			'categories' => ['alt-text-generator'],
+			'level' => LogLevel::INFO,
+			'logContext' => false,
+			'allowLineBreaks' => false,
+			'formatter' => new LineFormatter(
+				format: "%datetime% %message%\n",
+				dateFormat: 'Y-m-d H:i:s',
+			),
+		]);
+	}
+
+	/**
+	 * @param DefineHtmlEvent $event
+	 * @return void
+	 */
+	private function appendAssetEditPageButtons(DefineHtmlEvent &$event): void {
+		/** @see Asset::getAdditionalButtons() */
+		$event->html = Html::beginTag('div', ['class' => 'btngroup']);
+		$event->html .= Html::button(Craft::t('alt-text-generator', 'Generate alt text'), [
+			'id' => 'generateAltText-btn',
+			'class' => 'btn',
+			'data' => [
+				'icon' => 'wand',
+			],
+			'aria' => [
+				'label' => Craft::t('alt-text-generator', 'Generate alt text'),
+			],
+		]);
+
+		$js = <<<JS
+            $('#generateAltText-btn').on('click', () => {
+                let id = document.querySelector("input[name='elementId']").value;
+                Craft.sendActionRequest('POST', 'alt-text-generator/cp/queue-single-alt-text', {
+                    data: {
+                        assetId: id
                     }
-                );
-        }
-        
-        
-        Event::on(
-                UserPermissions::class,
-                UserPermissions::EVENT_REGISTER_PERMISSIONS,
-                function(RegisterUserPermissionsEvent $event) {
-                    $event->permissions[] = [
-                        'heading' => 'Alt Text Generator',
-                        'permissions' => [
-                            
-                            'altTextGeneratorWidgetStats' => [
-                                'label' => 'Stats widget',
-                            ],
-                            'altTextGeneratorViewDashboard' => [
-                                'label' => 'View dashboard',
-                                'nested' => [
-                                    'altTextGeneratorSyncAltText' => [
-                                        'label' => 'Sync generated alt text with asset',
-                                    ],
-                                    'altTextGeneratorHumanReview' => [
-                                        'label' => 'Request human review of AI generated alt text',
-                                    ],
-                                    'altTextGeneratorDelete' => [
-                                        'label' => 'Delete record',
-                                    ],
-                                    'altTextGeneratorRequestRefresh' => [
-                                        'label' => 'Refresh image data from altText.ai',
-                                    ],
-                                ],
-                            ],
-                            'altTextGeneratorViewHistory' => [
-                                    'label' => 'View history',
-                                ],
-                        
-                            'altTextGeneratorAssetAction' => [
-                                'label' => 'Queue alt text generation with asset actions',
-                            ],
-                       ],
-                    ];
-                }
-            );
-        
-       
-        // Create event to send asset to have alt text generated if that setting is set to true
-        if ($settings->generateOnSave === true) {
-            Event::on(
-            Asset::class,
-            Asset::EVENT_AFTER_PROPAGATE,
-            function(ModelEvent $event) {
-                if (($event->sender->enabled && $event->sender->getEnabledForSite()) &&
-                    $event->sender->firstSave && $event->sender->alt == "") {
-                    $currentUser = Craft::$app->getUser()->getIdentity();
-                    if ($currentUser) {
-                        $currentUserId = $currentUser->id;
-                    } else {
-                        $currentUserId = null;
-                    }
-                 
-                    Queue::push(new RequestAltTextJob([
-                        "assetId" => $event->sender->id,
-                        "requestUserId" => $currentUserId,
-                        "actionType" => "On save",
-                    ]));
-                }
-            }
-        );
-        } // if settings generateOnSave is true
-      
-        
-        
-        // Register the control panel routes.
-        Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES, function(RegisterUrlRulesEvent $event) {
-            $event->rules['alt-text-generator'] = 'alt-text-generator/cp/dashboard';
-            $event->rules['alt-text-generator/history'] = 'alt-text-generator/cp/history';
-            $event->rules['alt-text-generator/errors'] = 'alt-text-generator/cp/errors';
-        });
-        
-        // register event for when saving an asset
-        
-        
-        
-        
-        // Generate the encryption key that is unique to this installation.
-        Event::on(Plugins::class, Plugins::EVENT_AFTER_INSTALL_PLUGIN, function(PluginEvent $event) {
-            if ($event->plugin === $this) {
-                $initialSettings = ['securityCode' => Craft::$app->getSecurity()->generateRandomString(16)];
-                Craft::$app->getPlugins()->savePluginSettings($this, $initialSettings);
-            }
-        });
-        
-        Event::on(Dashboard::class, Dashboard::EVENT_REGISTER_WIDGET_TYPES, function(RegisterComponentTypesEvent $event) {
-            if (Craft::$app->user->checkPermission('altTextGeneratorWidgetStats')) {
-                $event->types[] = ImageAltTextStats::class;
-            }
-        });
-    }
-    
-         
-    public function getCpNavItem(): ?array
-    {
-        $numberOfItemsToReview = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextsToReview();
-        
-        
-        $item = parent::getCpNavItem();
-        $item['badgeCount'] = $numberOfItemsToReview;
-        $showNav = false;
-        if (Craft::$app->user->checkPermission('altTextGeneratorViewDashboard')) {
-            $item['subnav']['review'] = ['label' => 'Review', 'url' => 'alt-text-generator'];
-            $showNav = true;
-        }
-        if (Craft::$app->user->checkPermission('altTextGeneratorViewHistory')) {
-            $item['subnav'][ 'history'] = ['label' => 'History', 'url' => 'alt-text-generator/history'];
-            $showNav = true;
-        }
-        if (Craft::$app->user->checkPermission('altTextGeneratorViewHistory')) {
-            $item['subnav'][ 'errors'] = ['label' => 'Errors', 'url' => 'alt-text-generator/errors'];
-            $showNav = true;
-        }
-        if ($showNav == true) {
-            return $item;
-        } else {
-            return null;
-        }
-    }
+                })
+                .then((response) => {
+                    Craft.cp.displayNotice(Craft.t('alt-text-generator', 'Alt text generation queued'));
+                })
+                .catch((error) => {
+                    Craft.cp.displayError(Craft.t('alt-text-generator', 'Error queueing alt text generation'));
+                });
+            });
+        JS;
+		Craft::$app->getView()->registerJs($js);
+
+		$event->html .= Html::endTag('div');
+	}
 }

--- a/src/controllers/CpController.php
+++ b/src/controllers/CpController.php
@@ -5,143 +5,179 @@ namespace dispositiontools\craftalttextgenerator\controllers;
 use Craft;
 use craft\web\Controller;
 use dispositiontools\craftalttextgenerator\AltTextGenerator;
+use dispositiontools\craftalttextgenerator\jobs\RequestAltText as RequestAltTextJob;
 
 use yii\web\Response;
 
 /**
  * Cp controller
  */
-class CpController extends Controller
-{
-    public $defaultAction = 'index';
-    protected array|int|bool $allowAnonymous = self::ALLOW_ANONYMOUS_NEVER;
-
-    
-    /**
-     * alt-text-generator/cp/dashboard action
-     */
-    public function actionDashboard(): Response
-    {
-        // ...
-        $this->requirePermission('altTextGeneratorViewDashboard');
-        
-        $request = Craft::$app->getRequest();
-            
-       
-            
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        if (!$settings->apiKey) {
-            return $this->renderTemplate('alt-text-generator/_cp/setup', ['title' => 'Alt Text Generator']);
-        }
-
-        $apiCreditsCount = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
-    
-        // We need these three request parameters for the view. ("value" optional)
-        $templateParams = [
-            'title' => 'Alt Text Generator',
-            'settings' => $settings,
-            'credits' => $apiCreditsCount,
-            'apiCalls' => AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
-                'where' =>
-                [
-                    'altTextSyncStatus' => ['review'],
-                ],
-            ]),
-        ];
-        return $this->renderTemplate('alt-text-generator/_cp/dashboard', $templateParams);
-    }
-    
-    
-    
-    /**
-     * alt-text-generator/cp/history action
-     */
-    public function actionHistory(): Response
-    {
-        // ...
-        $this->requirePermission('altTextGeneratorViewHistory');
-        $request = Craft::$app->getRequest();
-            
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        
-    
-        // We need these three request parameters for the view. ("value" optional)
-        $templateParams = [
-            'title' => 'Alt Text Generator',
-            'settings' => $settings,
-            'apiCalls' => AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([]),
-        ];
-        return $this->renderTemplate('alt-text-generator/_cp/history', $templateParams);
-    }
+class CpController extends Controller {
+	public $defaultAction = 'index';
+	protected array|int|bool $allowAnonymous = self::ALLOW_ANONYMOUS_NEVER;
 
 
-     /**
-     * alt-text-generator/cp/errors action
-     */
-    public function actionErrors(): Response
-    {
-        // ...
-        $this->requirePermission('altTextGeneratorViewHistory');
-        $request = Craft::$app->getRequest();
-            
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        
-    
-        // We need these three request parameters for the view. ("value" optional)
-        $templateParams = [
-            'title' => 'Alt Text Generator',
-            'settings' => $settings,
-            'apiCalls' => AltTextGenerator::getInstance()->altTextAiApi->getApiCalls(['where' =>
-                [
-                    'altTextSyncStatus' => ['errors'],
-                ],
-            ]),
-        ];
-        return $this->renderTemplate('alt-text-generator/_cp/errors', $templateParams);
-    }
-    
-    
-    /**
-     * alt-text-generator/cp/queue-images action
-    */
-    public function actionQueueImages(): Response
-    {
-        $this->requirePostRequest();
-        $request = Craft::$app->getRequest();
-        $generateForNoAltText = $request->post('generateForNoAltText');
-        $generateForAltText = $request->post('generateForAltText');
-        
-        
-        
-        AltTextGenerator::getInstance()->altTextAiApi->queueAllImages($generateForNoAltText,$generateForAltText);
-            
-            
-        return $this->redirectToPostedUrl();
-    }
-    
-    
-    /**
-     * alt-text-generator/cp/refresh-api-token-count action
-    */
-    public function actionRefreshApiTokenCount(): Response
-    {
-        AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextApiCredits();
-        return $this->redirectToPostedUrl();
-    }
-    
-    /**
-     * alt-text-generator/cp/update-api-calls action
-    */
-    public function actionUpdateApiCalls(): Response
-    {
-        $request = Craft::$app->getRequest();
-        
-        $assets = $request->post('assets');
-        $altTextUpdates = $request->post('altTextUpdates');
-        
-        AltTextGenerator::getInstance()->altTextAiApi->updateApiCalls($assets, $altTextUpdates);
-            
-        // Go through each type of edit and get it done.
-        return $this->redirectToPostedUrl();
-    }
+	/**
+	 * alt-text-generator/cp/dashboard action
+	 */
+	public function actionDashboard(): Response {
+		// ...
+		$this->requirePermission('altTextGeneratorViewDashboard');
+
+		$request = Craft::$app->getRequest();
+
+
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		if (!$settings->getApiKey(true)) {
+			return $this->renderTemplate('alt-text-generator/_cp/setup', ['title' => 'Alt Text Generator']);
+		}
+
+		$apiCreditsCount = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
+
+		// We need these three request parameters for the view. ("value" optional)
+		$templateParams = [
+			'title' => 'Alt Text Generator',
+			'settings' => $settings,
+			'credits' => $apiCreditsCount,
+			'apiCalls' => AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
+				'where' =>
+				[
+					'altTextSyncStatus' => ['review'],
+				],
+			]),
+		];
+		return $this->renderTemplate('alt-text-generator/_cp/dashboard', $templateParams);
+	}
+
+
+
+	/**
+	 * alt-text-generator/cp/history action
+	 */
+	public function actionHistory(): Response {
+		// ...
+		$this->requirePermission('altTextGeneratorViewHistory');
+		$request = Craft::$app->getRequest();
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+
+		// We need these three request parameters for the view. ("value" optional)
+		$templateParams = [
+			'title' => 'Alt Text Generator',
+			'settings' => $settings,
+			'apiCalls' => AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([]),
+		];
+		return $this->renderTemplate('alt-text-generator/_cp/history', $templateParams);
+	}
+
+
+	/**
+	 * alt-text-generator/cp/errors action
+	 */
+	public function actionErrors(): Response {
+		// ...
+		$this->requirePermission('altTextGeneratorViewHistory');
+		$request = Craft::$app->getRequest();
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+
+		// We need these three request parameters for the view. ("value" optional)
+		$templateParams = [
+			'title' => 'Alt Text Generator',
+			'settings' => $settings,
+			'apiCalls' => AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
+				'where' =>
+				[
+					'altTextSyncStatus' => ['errors'],
+				],
+			]),
+		];
+		return $this->renderTemplate('alt-text-generator/_cp/errors', $templateParams);
+	}
+
+
+	/**
+	 * alt-text-generator/cp/queue-images action
+	 */
+	public function actionQueueImages(): Response {
+		$this->requirePostRequest();
+		$request = Craft::$app->getRequest();
+		$generateForNoAltText = $request->post('generateForNoAltText');
+		$generateForAltText = $request->post('generateForAltText');
+		$overwrite = $request->post('overwrite', false);
+
+
+
+		$queueAllImagesReport = AltTextGenerator::getInstance()->altTextAiApi->queueAllImages($generateForNoAltText, $generateForAltText, $overwrite);
+
+		return $this->renderTemplate('alt-text-generator/_cp/queue_all_report', [
+			"title" => "Queue Assets report",
+			"queueAllImagesReport" => $queueAllImagesReport
+		]);
+		//return $this->asSuccess(json_encode($queueAllImagesReport));
+	}
+
+
+
+
+	/**
+	 * alt-text-generator/cp/queue-all-images-for-resync action
+	 */
+	public function actionQueueAllImagesForResync(): Response {
+		$imagesQueuedForResync = AltTextGenerator::getInstance()->altTextAiApi->queueAllImagesForResync();
+
+		Craft::$app->getSession()->setSuccess($imagesQueuedForResync['imagesQueue'] . ' images queue for resync');
+
+		return $this->redirectToPostedUrl();
+	}
+
+
+	/**
+	 * alt-text-generator/cp/refresh-api-token-count action
+	 */
+	public function actionRefreshApiTokenCount(): Response {
+		AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextApiCredits();
+		return $this->redirectToPostedUrl();
+	}
+
+	/**
+	 * alt-text-generator/cp/update-api-calls action
+	 */
+	public function actionUpdateApiCalls(): Response {
+		$request = Craft::$app->getRequest();
+
+		$assets = $request->post('assets');
+		$altTextUpdates = $request->post('altTextUpdates');
+
+		AltTextGenerator::getInstance()->altTextAiApi->updateApiCalls($assets, $altTextUpdates);
+
+		// Go through each type of edit and get it done.
+		return $this->redirectToPostedUrl();
+	}
+
+	/**
+	 * alt-text-generator/cp/queue-single-alt-text action
+	 */
+	public function actionQueueSingleAltText(): Response {
+		$this->requirePostRequest();
+		$this->requireAcceptsJson();
+
+		$assetId = Craft::$app->getRequest()->getRequiredParam('assetId');
+
+		$siteId = Craft::$app->request->getQueryParam('site');
+		$currentSite = $siteId ? Craft::$app->getSites()->getSiteByHandle($siteId) : Craft::$app->getSites()->getPrimarySite();
+
+		Craft::$app->getQueue()->push(new RequestAltTextJob([
+			'assetId' => $assetId,
+			'requestUserId' => Craft::$app->getUser()->getId(),
+			'actionType' => 'Action',
+			"overwrite" => true,
+			"siteId" => $currentSite->id
+		]));
+
+		return $this->asJson(['success' => true]);
+	}
 }

--- a/src/elements/actions/GenerateAltText.php
+++ b/src/elements/actions/GenerateAltText.php
@@ -11,71 +11,57 @@ use dispositiontools\craftalttextgenerator\jobs\RequestAltText as RequestAltText
 /**
  * Generate Alt Text element action
  */
-class GenerateAltText extends ElementAction
-{
-    public static function displayName(): string
-    {
-        return Craft::t('alt-text-generator', 'Generate Alt Text');
-    }
+class GenerateAltText extends ElementAction {
+	public static function displayName(): string {
+		return Craft::t('alt-text-generator', 'Generate Alt Text');
+	}
 
-    public function getTriggerHtml(): ?string
-    {
-        Craft::$app->getView()->registerJsWithVars(fn($type) => <<<JS
+	public function getTriggerHtml(): ?string {
+		Craft::$app->getView()->registerJsWithVars(fn($type) => <<<JS
             (() => {
                 new Craft.ElementActionTrigger({
                     type: $type,
-
-                    // Whether this action should be available when multiple elements are selected
-                    bulk: true,
-
-                    // Return whether the action should be available depending on which elements are selected
-                    validateSelection: (selectedItems) {
-                      return true;
-                    },
-
-                    // Uncomment if the action should be handled by JavaScript:
-                    // activate: () => {
-                    //   Craft.elementIndex.setIndexBusy();
-                    //   const ids = Craft.elementIndex.getSelectedElementIds();
-                    //   // ...
-                    //   Craft.elementIndex.setIndexAvailable();
-                    // },
+                    bulk: true
                 });
             })();
         JS, [static::class]);
-            
-        return '';
-    }
 
-    public function performAction(Craft\elements\db\ElementQueryInterface $query): bool
-    {
-        $currentUser = Craft::$app->getUser()->getIdentity();
-        $numberOfCredits = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
-  
-        $elements = $query->all();
-        $numberOfElements = 0;
-        if (is_countable($elements)) {
-            $numberOfElements = count($elements);
-        }
+		return '';
+	}
 
-        if ($numberOfElements > $numberOfCredits) {
-            $this->setMessage('Your alttext.io account only has about ' . $numberOfCredits . " and you have selected " . $numberOfElements . " elements. Please reduce the number of assets selected and try again.");
-            return false;
-        }
+	public function performAction(Craft\elements\db\ElementQueryInterface $query): bool {
+		$currentUser = Craft::$app->getUser()->getIdentity();
+		$numberOfCredits = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
 
-        $returnMessage = "";
-        foreach ($elements as $element) {
-            Queue::push(new RequestAltTextJob([
-                "assetId" => $element->id,
-                "requestUserId" => $currentUser->id,
-            ]));
-        }
-        /**/
+		$elements = $query->all();
+		$numberOfElements = 0;
+		if (is_countable($elements)) {
+			$numberOfElements = count($elements);
+		}
 
-        $this->setMessage($numberOfElements . " elements have been queued with alttext.ai for alt text generation.");
+		if ($numberOfElements > $numberOfCredits) {
+			$this->setMessage('Your alttext.io account only has about ' . $numberOfCredits . " and you have selected " . $numberOfElements . " elements. Please reduce the number of assets selected and try again.");
+			return false;
+		}
 
-        return true;
+		$siteId = Craft::$app->request->getQueryParam('site');
+		$currentSite = $siteId ? Craft::$app->getSites()->getSiteByHandle($siteId) : Craft::$app->getSites()->getPrimarySite();
 
-        // ...
-    }
+		$returnMessage = "";
+		foreach ($elements as $element) {
+			Queue::push(new RequestAltTextJob([
+				"assetId" => $element->id,
+				"requestUserId" => $currentUser->id,
+				"overwrite" => true,
+				"siteId" => $currentSite->id
+			]));
+		}
+		/**/
+
+		$this->setMessage($numberOfElements . " elements have been queued with alttext.ai for alt text generation.");
+
+		return true;
+
+		// ...
+	}
 }

--- a/src/jobs/RequestAltText.php
+++ b/src/jobs/RequestAltText.php
@@ -2,26 +2,37 @@
 
 namespace dispositiontools\craftalttextgenerator\jobs;
 
+use Craft;
 use craft\queue\BaseJob;
 use dispositiontools\craftalttextgenerator\AltTextGenerator;
+use dispositiontools\craftalttextgenerator\errors\RequestAltTextException;
+
 
 /**
  * Request Alt Text queue job
  */
-class RequestAltText extends BaseJob
-{
-    public ?int $assetId = null;
-    public ?int $requestUserId = null;
-    public ?bool $overwrite = false;
-    public ?string $actionType = "Action";
-    
-    public function execute($queue): void
-    {
-        AltTextGenerator::getInstance()->altTextAiApi->callAltTextAiAipi($this->assetId,  $this->actionType, false, $this->requestUserId, $this->overwrite);
-    }
+class RequestAltText extends BaseJob {
+	public ?int $assetId = null;
+	public ?int $requestUserId = null;
+	public ?bool $overwrite = false;
+	public ?string $actionType = "Action";
+	public ?int $siteId = null;
 
-    protected function defaultDescription(): ?string
-    {
-        return "Request alt text";
-    }
+	public function execute($queue): void {
+		if (empty($this->siteId)) {
+			$this->siteId = Craft::$app->getSites()->getCurrentSite()->id;
+		}
+
+		$jobResult =   AltTextGenerator::getInstance()->altTextAiApi->callAltTextAiAipi($this->assetId,  $this->actionType, false, $this->requestUserId, $this->overwrite, $this->siteId);
+
+
+		if (isset($jobResult['error']) && $jobResult['error']) {
+			$errorMessage = "Error with Request Alt Text Job with meaage: " . $jobResult['errorMessage'];
+			throw new RequestAltTextException($errorMessage);
+		}
+	}
+
+	protected function defaultDescription(): ?string {
+		return "Request alt text";
+	}
 }

--- a/src/services/AltTextAiApi.php
+++ b/src/services/AltTextAiApi.php
@@ -16,1189 +16,1419 @@ use dispositiontools\craftalttextgenerator\jobs\UpdateAssetWithGeneratedAltText 
 
 use dispositiontools\craftalttextgenerator\models\AltTextAiApiCall as AltTextAiApiCallModel;
 use dispositiontools\craftalttextgenerator\records\AltTextAiApiCall as AltTextAiApiCallRecord;
+
+use dispositiontools\craftalttextgenerator\models\QueueAllReport as QueueAllReportModel;
+
 use yii\base\Component;
+use Exception;
 
 /**
  * Alt Text Ai Api service
  */
-class AltTextAiApi extends Component
-{
-    /**
-     * Stores apiCall to DB.
-     *
-     * @return model
-     */
-    public function saveApiCall(AltTextAiApiCallModel $model): AltTextAiApiCallModel
-    {
-        $isNew = !$model->id;
-        
-        if (!$isNew) {
-            $record = AltTextAiApiCallRecord::findOne(['id' => $model->id]);
-        } else {
-            $record = new AltTextAiApiCallRecord();
-        }
-            
-            
-        $fieldsToUpdate = [
-                'requestUserId',
-                'assetId',
-                'siteId',
-                'requestType',
-                'dateRequest',
-                'request',
-                'dateResponse',
-                'response',
-                'originalAltText',
-                'generatedAltText',
-                'altTextSyncStatus',
-                'humanResponse',
-                'humanDateResponse',
-                'humanRequest',
-                'humanDateRequest',
-                'humanGeneratedAltText',
-                'humanAltTextSyncStatus',
-                'humanRequestUserId',
-                'requestId',
-            ];
-            
-        foreach ($fieldsToUpdate as $handle) {
-            if (property_exists($model, $handle)) {
-                $record->$handle = $model->$handle;
-            }
-        }
-        
-        $record->validate();
-        $model->addErrors($record->getErrors());
-        
+class AltTextAiApi extends Component {
+	/**
+	 * Stores apiCall to DB.
+	 *
+	 * @return model
+	 */
+	public function saveApiCall(AltTextAiApiCallModel $model): AltTextAiApiCallModel {
+		$isNew = !$model->id;
 
-        $record->save(false);
+		if (!$isNew) {
+			$record = AltTextAiApiCallRecord::findOne(['id' => $model->id]);
+		} else {
+			$record = new AltTextAiApiCallRecord();
+		}
 
-        if ($isNew) {
-            $model->id = $record->id;
-        }
-        
-        return  $model;
-    }
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->statsImagesWithAltText( );
-    public function statsImagesWithAltText(): array
-    {
-        $assetsQuery = AssetElement::find()->kind('image')->hasAlt(false);
-        $assets = $assetsQuery->all();
-        $imagesWithoutAltText = 0;
-        if(is_countable($assets ))
-        {
-            $imagesWithoutAltText = count($assets);
-        }
-        unset($assets);
-        unset($assetsQuery);
-        
-       
-       
-        $assetsQuery = AssetElement::find()->kind('image')->hasAlt(true);
-        $assets = $assetsQuery->all();
-        $imagesWithAltText = 0;
-        if(is_countable($assets ))
-        {
-            $imagesWithAltText = count($assets);
-        }
 
-        unset($assets);
-        unset($assetsQuery);
-        
-        return [
-           'imagesWithoutAltText' => $imagesWithoutAltText,
-           'imagesWithAltText' => $imagesWithAltText,
-        ];
-    }
-    
-    
-    /*
+		$fieldsToUpdate = [
+			'requestUserId',
+			'assetId',
+			'siteId',
+			'requestType',
+			'dateRequest',
+			'request',
+			'dateResponse',
+			'response',
+			'originalAltText',
+			'generatedAltText',
+			'altTextSyncStatus',
+			'humanResponse',
+			'humanDateResponse',
+			'humanRequest',
+			'humanDateRequest',
+			'humanGeneratedAltText',
+			'humanAltTextSyncStatus',
+			'humanRequestUserId',
+			'requestId',
+		];
+
+		foreach ($fieldsToUpdate as $handle) {
+			if (property_exists($model, $handle)) {
+				$record->$handle = $model->$handle;
+			}
+		}
+
+		$record->validate();
+		$model->addErrors($record->getErrors());
+
+
+		$record->save(false);
+
+		if ($isNew) {
+			$model->id = $record->id;
+		}
+
+		return  $model;
+	}
+
+	// AltTextGenerator::getInstance()->altTextAiApi->statsImagesWithAltText( );
+	public function statsImagesWithAltText(): array {
+		$stats = [];
+		$sites = Craft::$app->getSites()->getAllSites();
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$customField = $settings->customField;
+
+		foreach ($sites as $site) {
+			if ($customField && ($settings->customField == "alt" || $settings->customField == null)) {
+				$assetsQuery = AssetElement::find()->kind('image')->hasAlt(false)->siteId($site->id);
+			} else {
+				try {
+					$assetsQuery = AssetElement::find()->kind('image')->$customField(':empty:')->siteId($site->id);
+				} catch (Exception $e) {
+					$assetsQuery = AssetElement::find()->kind('image')->hasAlt(false)->siteId($site->id);
+				}
+			}
+
+			$assets = $assetsQuery->all();
+			$stats[$site->id] = [
+				'imagesWithoutAltText' => is_countable($assets) ? count($assets) : 0,
+				'imagesWithAltText' => 0
+			];
+
+			// Similar for imagesWithAltText count
+		}
+
+		return $stats;
+	}
+
+	/*
          Called from the review page in the CP
     */
-    
-    // AltTextGenerator::getInstance()->updateApiCalls( $assets, $altTextUpdates );
-    public function updateApiCalls($assets, $altTextUpdates = null): ?bool
-    {
-        $currentUser = Craft::$app->getUser()->getIdentity();
-        if ($currentUser) {
-            $currentUserId = $currentUser->id;
-        } else {
-            $currentUserId = null;
-        }
-       
-        if ($assets) {
-            foreach ($assets as $apiCallId => $type) {
-                switch ($type) {
-                     
-                     case "generatedSync":
-                        
-                              $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                                if ($AltTextAiApiCallModel) {
-                                    $AltTextAiApiCallModel->altTextSyncStatus = "syncing";
 
-                                    if($altTextUpdates && isset($altTextUpdates['generatedAltText'][$apiCallId]) )
-                                    {
-                                        $AltTextAiApiCallModel->generatedAltText = $altTextUpdates['generatedAltText'][$apiCallId];
-                                    }
+	// AltTextGenerator::getInstance()->updateApiCalls( $assets, $altTextUpdates );
+	public function updateApiCalls($assets, $altTextUpdates = null): ?bool {
+		$currentUser = Craft::$app->getUser()->getIdentity();
+		if ($currentUser) {
+			$currentUserId = $currentUser->id;
+		} else {
+			$currentUserId = null;
+		}
 
-                                    $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-                                    Queue::push(new UpdateAssetWithGeneratedAltTextJob([
-                                         "apiCallId" => $AltTextAiApiCallModel->id,
-                                         "type" => "generated",
-                                     ]));
-                                     
-                                    unset($AltTextAiApiCallModel);
-                                }
-                        
-                        break;
-                     
-                     case "originalSync":
-                        
-                              $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                                if ($AltTextAiApiCallModel) {
-                                    Queue::push(new UpdateAssetWithGeneratedAltTextJob([
-                                         "apiCallId" => $AltTextAiApiCallModel->id,
-                                         "type" => "original",
-                                     ]));
-                                     
-                                    unset($AltTextAiApiCallModel);
-                                }
-                     
-                        break;
-                     
-                     case "humanGeneratedSync":
-                        
-                           $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                             if ($AltTextAiApiCallModel) {
-                                 $AltTextAiApiCallModel->altTextSyncStatus = "syncing";
+		if ($assets) {
+			foreach ($assets as $apiCallId => $type) {
+				switch ($type) {
 
-                                 if($altTextUpdates && isset($altTextUpdates['humanGeneratedAltText'][$apiCallId]) )
-                                 {
-                                     $AltTextAiApiCallModel->humanGeneratedAltText = $altTextUpdates['humanGeneratedAltText'][$apiCallId];
-                                 }
+					case "generatedSync":
 
-                                 $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-                                 
-                                 Queue::push(new UpdateAssetWithGeneratedAltTextJob([
-                                      "apiCallId" => $AltTextAiApiCallModel->id,
-                                      "type" => "humanGenerated",
-                                  ]));
-                                  
-                                 unset($AltTextAiApiCallModel);
-                             }
-                           
-                        
-                             
-                        break;
-                        
-                    case "requestRefresh":
-                        
-                                $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                                 if ($AltTextAiApiCallModel) {
-                                     $AltTextAiApiCallModel->altTextSyncStatus = "refreshing";
-                                     $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-                                     
-                                     Queue::push(new RefreshImageDetailsJob([
-                                          "apiCallId" => $AltTextAiApiCallModel->id,
-                                          "humanRequestUserId" => $currentUserId,
-                                      ]));
-                                      
-                                     unset($AltTextAiApiCallModel);
-                                 }
-                        
-                        break;
+						$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+						if ($AltTextAiApiCallModel) {
+							$AltTextAiApiCallModel->altTextSyncStatus = "syncing";
 
-                    case "requestResubmit":
+							if ($altTextUpdates && isset($altTextUpdates['generatedAltText'][$apiCallId])) {
+								$AltTextAiApiCallModel->generatedAltText = $altTextUpdates['generatedAltText'][$apiCallId];
+							}
 
-                        $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                                 if ($AltTextAiApiCallModel) {
-                                     $AltTextAiApiCallModel->altTextSyncStatus = "resubmit";
-                                     $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-                                     
-                                     Queue::push(new RequestAltTextJob([
-                                          "assetId" => $AltTextAiApiCallModel->assetId,
-                                          "overwrite" => true,
-                                          "requestUserId" => $currentUserId,
-                                          "actionType" => "Review"
-                                      ]));
-                                      
-                                     unset($AltTextAiApiCallModel);
-                                 }
+							$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+							Queue::push(new UpdateAssetWithGeneratedAltTextJob([
+								"apiCallId" => $AltTextAiApiCallModel->id,
+								"type" => "generated",
+							]));
+
+							unset($AltTextAiApiCallModel);
+						}
+
+						break;
+
+					case "originalSync":
+
+						$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+						if ($AltTextAiApiCallModel) {
+							Queue::push(new UpdateAssetWithGeneratedAltTextJob([
+								"apiCallId" => $AltTextAiApiCallModel->id,
+								"type" => "original",
+							]));
+
+							unset($AltTextAiApiCallModel);
+						}
+
+						break;
+
+					case "humanGeneratedSync":
+
+						$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+						if ($AltTextAiApiCallModel) {
+							$AltTextAiApiCallModel->altTextSyncStatus = "syncing";
+
+							if ($altTextUpdates && isset($altTextUpdates['humanGeneratedAltText'][$apiCallId])) {
+								$AltTextAiApiCallModel->humanGeneratedAltText = $altTextUpdates['humanGeneratedAltText'][$apiCallId];
+							}
+
+							$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+							Queue::push(new UpdateAssetWithGeneratedAltTextJob([
+								"apiCallId" => $AltTextAiApiCallModel->id,
+								"type" => "humanGenerated",
+							]));
+
+							unset($AltTextAiApiCallModel);
+						}
 
 
 
-                        break;
-                        
-                     case "requestHuman":
-                        
-                           $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                             if ($AltTextAiApiCallModel) {
-                                 Queue::push(new RequestHumanAltTextReviewJob([
-                                      "apiCallId" => $AltTextAiApiCallModel->id,
-                                      "humanRequestUserId" => $currentUserId,
-                                  ]));
-                                  
-                                 unset($AltTextAiApiCallModel);
-                             }
-                           
-                    
-                        break;
-                        
-                     case "delete":
-                           
-                           $record = AltTextAiApiCallRecord::findOne(['id' => $apiCallId]);
-                           $record->softDelete();
-                           unset($record);
-                     
-                        break;
-                        
-                     case "cancel":
-                        // don't do anything
-                        break;
-                     
-                  }
-            }
-               
-            // update the plugin badge count
-            AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextsToReview();
-        }
-      
-         
-        return true;
-    }
-    
-    
-    public function getAssetAndCheck($assetId)
-    {
-        // get the element
-                
-        $asset = AssetElement::find()->id($assetId)->one();
-             
-        if (!$asset) {
-            return false;
-        }
-         
-        $suitability = $this->checkAssetSuitability($asset);
-           
-        if (!$suitability['success']) {
-            return false;
-        }
-           
-        return  $asset;
-    }
-    
-    
-    // AltTextGenerator::getInstance()->refreshImageDetailsFromAltTextAi( $apiCallId );
-    public function refreshImageDetailsFromAltTextAi($apiCallId, $requestUserId = false)
-    {
-        $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-        
-        if (!$AltTextAiApiCallModel) {
-            return false;
-        }
-        
-        
-        $requestId = $AltTextAiApiCallModel->requestId;
-        if (!$requestId) {
-            $requestId = $AltTextAiApiCallModel->id;
-        }
-        
-        
-        
-        $imageDetails = $this->makeGetImageByAssetIdApiCall($requestId);
-        
-        if (!$imageDetails) {
-            return false;
-        }
-        
-        $imageDetailsArray = json_decode($imageDetails, true);
-        if (!$imageDetailsArray) {
-            return false;
-        }
-        
-        $asset = AssetElement::find()->id($AltTextAiApiCallModel->assetId)->one();
-              
-        if (!$asset) {
-            return false;
-        }
-        
-        $updateModel = false;
-        if ($imageDetailsArray['alt_text']) {
-            if (
-                $AltTextAiApiCallModel->humanDateRequest
-                && $imageDetailsArray['alt_text'] != $AltTextAiApiCallModel->generatedAltText
-                && $imageDetailsArray['alt_text'] != $AltTextAiApiCallModel->humanGeneratedAltText
-            ) {
-                $AltTextAiApiCallModel->humanGeneratedAltText = $imageDetailsArray['alt_text'];
-                $AltTextAiApiCallModel->humanAltTextSyncStatus = "review";
-                $AltTextAiApiCallModel->altTextSyncStatus = "review";
-                $updateModel = true;
-            } elseif ($imageDetailsArray['alt_text'] != $AltTextAiApiCallModel->generatedAltText) {
-                $AltTextAiApiCallModel->generatedAltText = $imageDetailsArray['alt_text'];
-                $AltTextAiApiCallModel->altTextSyncStatus = "review";
-                $updateModel = true;
-            }
-            
-            if ($updateModel) {
-                $this->saveApiCall($AltTextAiApiCallModel);
-            }
-        }
-        
-        
-        
-        
-        return true;
-    }
-    
-    
-    public function updateAssetWithGeneratedAltText($apiCallId, $type = "generated")
-    {
-        if (!$apiCallId) {
-            return false;
-        }
-        $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-       
-        if (!$AltTextAiApiCallModel) {
-            return false;
-        }
-        
-        if (!$AltTextAiApiCallModel->assetId) {
-            return false;
-        }
-      
-        // get Asset
-        $asset = $this->getAssetAndCheck($AltTextAiApiCallModel->assetId);
-        if (!$asset) {
-            return false;
-        }
-      
-        switch ($type) {
-               case "generated":
-                  
-                     if ($AltTextAiApiCallModel->generatedAltText != "") {
-                         $asset->alt = $AltTextAiApiCallModel->generatedAltText;
-                         $success = Craft::$app->elements->saveElement($asset);
-                         $AltTextAiApiCallModel->altTextSyncStatus = "synced";
-                         $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-                     }
-                  
-                  break;
-                  
-                  
-               case "original":
-               
-                  if ($AltTextAiApiCallModel->originalAltText != "") {
-                      $asset->alt = $AltTextAiApiCallModel->originalAltText;
-                      $success = Craft::$app->elements->saveElement($asset);
-                  }
-               
-                  break;
-                  
-               case "humanGenerated":
-               
-                  if ($AltTextAiApiCallModel->humanGeneratedAltText != "") {
-                      $asset->alt = $AltTextAiApiCallModel->humanGeneratedAltText;
-                      $success = Craft::$app->elements->saveElement($asset);
-                      $AltTextAiApiCallModel->altTextSyncStatus = "synced";
-                      $AltTextAiApiCallModel->humanGeneratedAltText = "synced";
-                      $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-                  }
-               
-                  break;
-         }
-      
-        
-        
-        return true;
-    }
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->getApiCalls( );
-    public function getApiCalls($criteria = null): array
-    {
-        $recordsQuery = AltTextAiApiCallRecord::find();
-      
-        if (array_key_exists('where', $criteria)) {
-            $x = 0;
-    
-            foreach ($criteria['where'] as $criteriaItem => $criteriaValue) {
-                $x++;
-                if ($x == 1) {
-                    $recordsQuery->where([$criteriaItem => $criteriaValue]);
-                } else {
-                    $recordsQuery->andWhere([$criteriaItem => $criteriaValue]);
-                }
-            }
-            
-            $recordsQuery->andWhere(["dateDeleted" => null]);
-        }
-         
-        $records = $recordsQuery->all();
-        
-        $models = array();
-       
-        foreach ($records as $record) {
-            $model = new AltTextAiApiCallModel($record->getAttributes());
-            $models[] = $model;
-        }
-       
-        return $models;
-    }
-    
-    public function getApiCallById($id): ?AltTextAiApiCallModel
-    {
-        $record = AltTextAiApiCallRecord::findOne(['id' => $id]);
-        
-        if (!$record) {
-            return null;
-        }
-        
-        $model = new AltTextAiApiCallModel($record->getAttributes());
-        return $model;
-    }
-    
-    
-    public function getApiCallByAssetId($id): ?AltTextAiApiCallModel
-    {
-        $record = AltTextAiApiCallRecord::findOne(['assetId' => $id]);
-        
-        if (!$record) {
-            return null;
-        }
-        
-        $model = new AltTextAiApiCallModel($record->getAttributes());
-        return $model;
-    }
-    
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->checkGetApiCallById( $id );
-    public function checkGetApiCallById($id)
-    {
-        $model = $this->getApiCallById($id);
-        
-        print_r($model);
-    }
-    
-    
-    public function checkAssetSuitability($asset): array
-    {
-        
-        // is the element type webp / png / jpg / BMP
-        if (!$asset->kind == "image") {
-            return [
-                'error' => true,
-                'errorMessage' => "Not an image",
-                'success' => false,
-            ];
-        }
-        
-        
-        if (!in_array(strtolower($asset->extension), ['jpg', 'gif', 'png', 'webp', 'jpeg'])) {
-            return [
-                'error' => true,
-                'errorMessage' => "Not right kind of image",
-                'success' => false,
-            ];
-        }
-        
-        
-        // check if the image is less than 10mb
-          
-        if ($asset->size > 10000000) {
-            return [
-                'error' => true,
-                'errorMessage' => "Image file size is over 10mb",
-                'success' => false,
-            ];
-        }
-        
-        // check if the image is over 50 x 50
-        if ($asset->width < 51 || $asset->height < 51) {
-            return [
-                'error' => true,
-                'errorMessage' => "Image needs to over 50 x 50 pixels",
-                'success' => false,
-            ];
-        }
-        
-        
-        return [
-            'error' => false,
-            'errorMessage' => "",
-            'success' => true,
-        ];
-    }
-    
-    
-    public function callAltTextAiHumanReviewAipi($apiCallId, $humanRequestUserId = null)
-    {
-        // get apiCall model
-        //
-        
-        $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-        
-        if (!$AltTextAiApiCallModel) {
-            //echo "no model";
-            return true;
-        }
-        
-        $asset = AssetElement::find()->id($AltTextAiApiCallModel->assetId)->one();
-              
-        if (!$asset) {
-            $return = [
-                  'error' => true,
-                  'errorMessage' => "No asset",
-              ];
-            return $return;
-        }
-          
-        $suitability = $this->checkAssetSuitability($asset);
-         
-        if (!$suitability['success']) {
-            return $suitability;
-        }
-        
-        $AltTextAiApiCallModel->humanRequestUserId = $humanRequestUserId;
-        $AltTextAiApiCallModel->humanAltTextSyncStatus = "requesting";
-        $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-        
-        $requestId = $AltTextAiApiCallModel->requestId;
-        if (!$requestId) {
-            $requestId = $AltTextAiApiCallModel->id;
-        }
-        
-        $resultsJson = $this->requestHumanReviewApiCall($requestId);
-    
+						break;
 
-        if ($resultsJson) {
-            $AltTextAiApiCallModel->humanAltTextSyncStatus = "requested";
-            $AltTextAiApiCallModel->humanRequest = json_encode($resultsJson);
-            $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-        }
-    }
-    
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->callAltTextAiAipi( $assetId );
-    public function callAltTextAiAipi($assetId, $requestType = "No type", $async = false, $requestUserId = false, $overwrite = false)
-    {
+					case "requestRefresh":
 
-        // see if the asset has already been called
-        // we are not allowed to recall it. so we will set it to review again
+						$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+						if ($AltTextAiApiCallModel) {
+							$AltTextAiApiCallModel->altTextSyncStatus = "refreshing";
+							$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
 
-        $AltTextAiApiCallModel = $this->getApiCallByAssetId($assetId);
+							Queue::push(new RefreshImageDetailsJob([
+								"apiCallId" => $AltTextAiApiCallModel->id,
+								"humanRequestUserId" => $currentUserId,
+							]));
 
-        if ($AltTextAiApiCallModel && $overwrite == false) {
-            $AltTextAiApiCallModel->altTextSyncStatus = "refreshing";
-            $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+							unset($AltTextAiApiCallModel);
+						}
 
-            Queue::push(new RefreshImageDetailsJob([
-                  "apiCallId" => $AltTextAiApiCallModel->id,
-                  "humanRequestUserId" => $requestUserId,
-              ]));
-            return true;
-        }
-        elseif($AltTextAiApiCallModel && $overwrite)
-        {
-            //
-        }
-        else {
-            $AltTextAiApiCallModel = new AltTextAiApiCallModel();
-        }
+						break;
+
+					case "requestResubmit":
+
+						$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+						if ($AltTextAiApiCallModel) {
+							$AltTextAiApiCallModel->altTextSyncStatus = "resubmit";
+							$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+							Queue::push(new RequestAltTextJob([
+								"assetId" => $AltTextAiApiCallModel->assetId,
+								"overwrite" => true,
+								"requestUserId" => $currentUserId,
+								"actionType" => "Review",
+								"siteId" => $AltTextAiApiCallModel->siteId,
+							]));
+
+							unset($AltTextAiApiCallModel);
+						}
 
 
-        // get the element
-        $asset = AssetElement::find()->id($assetId)->one();
 
-        if (!$asset) {
-            return [
-                'error' => true,
-                'errorMessage' => "No asset",
-            ];
-        }
+						break;
 
-        $suitability = $this->checkAssetSuitability($asset);
+					case "requestHuman":
 
-        if (!$suitability['success']) {
-            return $suitability;
-        }
+						$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+						if ($AltTextAiApiCallModel) {
+							Queue::push(new RequestHumanAltTextReviewJob([
+								"apiCallId" => $AltTextAiApiCallModel->id,
+								"humanRequestUserId" => $currentUserId,
+							]));
 
-        // check if we have enough credits
-        // if we don't have credits pause this...
+							unset($AltTextAiApiCallModel);
+						}
 
 
-        // create an rquestId
-        // Craft::$app->getSystemUid()
+						break;
 
-        $requestId = StringHelper::toKebabCase(Craft::$app->getSystemName()) . "_" . $asset->uid . "_" . $asset->id;
+					case "delete":
 
-        // create a call model
+						$record = AltTextAiApiCallRecord::findOne(['id' => $apiCallId]);
+						$record->softDelete();
+						unset($record);
 
-        $assetUrl = $asset->url;
+						break;
 
-        
+					case "cancel":
+						// don't do anything
+						break;
+				}
+			}
 
-        $AltTextAiApiCallModel->assetId = $asset->id;
-        $AltTextAiApiCallModel->requestId = $requestId;
-        $AltTextAiApiCallModel->requestType = $requestType;
-        $AltTextAiApiCallModel->dateRequest = DateTimeHelper::currentUTCDateTime();
-        if($overwrite)
-        {
-            $AltTextAiApiCallModel->altTextSyncStatus = "recalled";
-        }
-        else{
-            $AltTextAiApiCallModel->altTextSyncStatus = "called";
-        }   
-        
-        $AltTextAiApiCallModel->originalAltText = $asset->alt;
-
-        if ($requestUserId) {
-            $AltTextAiApiCallModel->requestUserId = $requestUserId;
-        }
-
-        // do the call
-
-        $settings = AltTextGenerator::getInstance()->getSettings();
-
-        $modelName = $settings->modelName;
-        if($modelName == "" || $modelName == null)
-        {
-            $modelName = "describe-regular";
-        }
-
-        $lang = $settings->lang;
-        if($lang == "" || $lang == null)
-        {
-            $lang = "en";
-        }
-
-        $webHookParams = [
-            'securityCode' => $settings->securityCode,
-        ];
-        $webhookUrl = UrlHelper::actionUrl('alt-text-generator/alt-text-ai-webhook/web-hook', $webHookParams, null, false);
-        $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-
-        $imageUrl = UrlHelper::siteUrl($assetUrl);
-
-        $callDetails = [
-            "image" => [
-                "url" => $imageUrl,
-                "asset_id" => $AltTextAiApiCallModel->requestId,
-                "metadata" => [
-                   "assetId" => $asset->id,
-                   "apiCallId" => $AltTextAiApiCallModel->id,
-                ],
-            ],
-            "model_name" => $modelName,
-            "async" => (bool) $settings->asyncApi,
-            "lang" => $lang
-        ];
-
-        if ($settings->asyncApi) {
-            $callDetails['webhook_url'] = $webhookUrl;
-        }
-
-        if( $overwrite ){
-            $callDetails['overwrite'] = true;
-        }
-
-        $AltTextAiApiCallModel->request = json_encode($callDetails);
-        $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+			// update the plugin badge count
+			AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextsToReview();
+		}
 
 
-        $resultsJson = $this->makeCreateImageApiCall($callDetails);
+		return true;
+	}
 
-        $AltTextAiApiCallModel->response = $resultsJson;
-        $AltTextAiApiCallModel->dateResponse = DateTimeHelper::currentUTCDateTime();
-        $AltTextAiApiCallModel->altTextSyncStatus = "received";
-        $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
 
-        $resultsArray = json_decode($resultsJson, true);
+	/*
+         Queue all imges for resyncing.
+    */
 
-        if($resultsArray && array_key_exists('errors', $resultsArray ) && count($resultsArray['errors']) > 0)
-        {
-            $AltTextAiApiCallModel->altTextSyncStatus = "errors";
-            $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-        }
+	// AltTextGenerator::getInstance()->queueAllImagesForResync();
+	public function queueAllImagesForResync() {
 
-        elseif (!$async && $resultsArray && array_key_exists('alt_text', $resultsArray )) {
+		// select all api calls where the status is synced
+		$recordsQuery = AltTextAiApiCallRecord::find();
 
-            $newAltText = $resultsArray['alt_text'];
-            $AltTextAiApiCallModel->generatedAltText = $newAltText;
+		$recordsQuery->where(["altTextSyncStatus" => "synced"]);
+		$recordsQuery->andWhere(["dateDeleted" => null]);
+		$records = $recordsQuery->all();
 
-            if ($settings->useAltTextImmediately) {
-                $asset->alt = $newAltText;
-                $success = Craft::$app->elements->saveElement($asset);
-                $AltTextAiApiCallModel->altTextSyncStatus = "synced";
-            } else {
-                $AltTextAiApiCallModel->altTextSyncStatus = "review";
-            }
+		foreach ($records as $record) {
+			$model = new AltTextAiApiCallModel($record->getAttributes());
+			if ($model->generatedAltText != null) {
+				Queue::push(new UpdateAssetWithGeneratedAltTextJob([
+					"apiCallId" => $model->id,
+					"type" => "generated",
+				]));
+			}
+			unset($model);
+		}
 
-            $AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
-        }
+		return ["imagesQueue" => count($records)];
+	}
+
+
+	public function getAssetAndCheck($assetId, $siteId = null) {
+		// get the element
+
+		$asset = AssetElement::find()->id($assetId);
+		if ($siteId) {
+			$asset->siteId($siteId);
+		}
+		$asset = $asset->one();
+
+		if (!$asset) {
+			return false;
+		}
+
+		$suitability = $this->checkAssetSuitability($asset);
+
+		if (!$suitability['success']) {
+			return false;
+		}
+
+		return  $asset;
+	}
+
+
+	// AltTextGenerator::getInstance()->refreshImageDetailsFromAltTextAi( $apiCallId );
+	public function refreshImageDetailsFromAltTextAi($apiCallId, $requestUserId = false) {
+		$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+
+		if (!$AltTextAiApiCallModel) {
+			return false;
+		}
+
+
+		$requestId = $AltTextAiApiCallModel->requestId;
+		if (!$requestId) {
+			$requestId = $AltTextAiApiCallModel->id;
+		}
+
+		$imageDetails = $this->makeGetImageByAssetIdApiCall($requestId);
+
+		$logMessage = "Refreshing image response: " . $apiCallId;
+		AltTextGenerator::info($logMessage);
+		AltTextGenerator::info($imageDetails);
+
+		if (!$imageDetails) {
+			return false;
+		}
+
+		$imageDetailsArray = json_decode($imageDetails, true);
+		if (!$imageDetailsArray) {
+			return false;
+		}
+
+		$asset = AssetElement::find()->id($AltTextAiApiCallModel->assetId);
+		if ($AltTextAiApiCallModel->siteId) {
+			$asset->siteId($AltTextAiApiCallModel->siteId);
+		}
+		$asset = $asset->one();
+
+		if (!$asset) {
+			$logMessage = "Refreshing image: Not found asset: " . $AltTextAiApiCallModel->assetId . " siteId: " . $AltTextAiApiCallModel->siteId;
+			AltTextGenerator::info($logMessage);
+			return false;
+		}
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		$updateModel = false;
+		if ($imageDetailsArray['alt_text']) {
+			if (
+				$AltTextAiApiCallModel->humanDateRequest
+				&& $imageDetailsArray['alt_text'] != $AltTextAiApiCallModel->generatedAltText
+				&& $imageDetailsArray['alt_text'] != $AltTextAiApiCallModel->humanGeneratedAltText
+			) {
+				$AltTextAiApiCallModel->humanGeneratedAltText = $imageDetailsArray['alt_text'];
+				$AltTextAiApiCallModel->humanAltTextSyncStatus = "review";
+				$AltTextAiApiCallModel->altTextSyncStatus = "review";
+				$updateModel = true;
+			} elseif ($imageDetailsArray['alt_text'] != $AltTextAiApiCallModel->generatedAltText) {
+				$AltTextAiApiCallModel->generatedAltText = $imageDetailsArray['alt_text'];
+				$AltTextAiApiCallModel->altTextSyncStatus = "review";
+				$updateModel = true;
+			} elseif ($imageDetailsArray['alt_text'] == $AltTextAiApiCallModel->generatedAltText) {
+
+				if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+
+					$currentAltText =  $asset->alt;
+				} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+
+					$currentAltText = $asset->getFieldValue($settings->customField);
+				} else {
+					$currentAltText =  $asset->alt;
+				}
+
+				if (trim($currentAltText) == trim($imageDetailsArray['alt_text'])) {
+					$AltTextAiApiCallModel->altTextSyncStatus = "synced";
+					$updateModel = true;
+				} else {
+					$AltTextAiApiCallModel->altTextSyncStatus = "review";
+					$updateModel = true;
+				}
+			}
+
+			if ($updateModel) {
+				$logMessage = "Refreshing image: updating apicall: " . $AltTextAiApiCallModel->id;
+				//AltTextGenerator::info($logMessage);
+				//AltTextGenerator::info($imageDetails);
+				$this->saveApiCall($AltTextAiApiCallModel);
+			}
+		} else {
+			//$logMessage = "Refreshing image: alt text array not found: apicall: ".$AltTextAiApiCallModel->id;
+			//AltTextGenerator::info($logMessage);
+		}
 
 
 
 
-        // what is they get a 429 error
+		return true;
+	}
 
 
-        // what if it already exists?
-        // then we need to update the asset straight away
-    }
-    
-    
-    
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->processAltTextAiWebhook( $hookData );
-    public function processAltTextAiWebhook($hookData)
-    {
-        // this saves the hook data to the api call hook
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        
-        $responseArray = json_decode($hookData, true);
-        
-      
-        if ($responseArray && array_key_exists("event", $responseArray)) {
-            if ($responseArray['event'] == "uploaded") {
-                $this->processAltTextAiWebhookUploaded($hookData);
-            }
-            
-            if ($responseArray['event'] == "reviewed") {
-                $this->processAltTextAiWebhookReviewed($hookData);
-            }
-        }
-        unset($hookData);
-        unset($responseArray);
-    }
-    
-    
-    public function processAltTextAiWebhookUploaded($hookData)
-    {
-        $responseArray = json_decode($hookData, true);
-        
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        
-        if (is_array($responseArray) && array_key_exists("data", $responseArray) && array_key_exists("images", $responseArray['data'])) {
-            foreach ($responseArray['data']['images'] as $imageResponse) {
-                if (array_key_exists('asset_id',  $imageResponse)) {
-                    $apiCallId = $imageResponse['asset_id'];
-                    if (array_key_exists('metadata',  $imageResponse) && array_key_exists('apiCallId',  $imageResponse['metadata'])) {
-                        $apiCallId = $imageResponse['metadata']['apiCallId'];
-                    }
-                       
-                    $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                       
-                    if ($AltTextAiApiCallModel) {
-                        $AltTextAiApiCallModel->dateResponse = DateTimeHelper::currentUTCDateTime();
-                        $AltTextAiApiCallModel->response = $hookData;
-                           
-                        $AltTextAiApiCallModel->generatedAltText = $imageResponse['alt_text'];
-                           
-                        if ($settings->useAltTextImmediately === true) {
-                            $asset = AssetElement::find()->id($AltTextAiApiCallModel->assetId)->one();
-                            if ($asset) {
-                                $asset->alt = $imageResponse['alt_text'];
-                                $success = Craft::$app->elements->saveElement($asset);
-                                $AltTextAiApiCallModel->altTextSyncStatus = "synced";
-                                
-                                unset($asset);
-                            } else {
-                                $AltTextAiApiCallModel->altTextSyncStatus = "review";
-                            }
-                        } else {
-                            $AltTextAiApiCallModel->altTextSyncStatus = "review";
-                        }
-                           
-                           
-                        $this->saveApiCall($AltTextAiApiCallModel);
-                        unset($AltTextAiApiCallModel);
-                    }
-                }
-            }
-        }
-        
-       
-        unset($responseArray);
-    }
-    
-    
-    public function processAltTextAiWebhookReviewed($hookData)
-    {
-        $responseArray = json_decode($hookData, true);
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        
-        if (is_array($responseArray) && array_key_exists("data", $responseArray) && array_key_exists("images", $responseArray['data'])) {
-            foreach ($responseArray['data']['images'] as $imageResponse) {
-                if (array_key_exists('asset_id',  $imageResponse)) {
-                    $apiCallId = $imageResponse['asset_id'];
-                    if (array_key_exists('metadata',  $imageResponse) && array_key_exists('apiCallId',  $imageResponse['metadata'])) {
-                        $apiCallId = $imageResponse['metadata']['apiCallId'];
-                    }
-                       
-                    $AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
-                       
-                    if ($AltTextAiApiCallModel) {
-                        $AltTextAiApiCallModel->humanDateResponse = DateTimeHelper::currentUTCDateTime();
-                        $AltTextAiApiCallModel->humanResponse = $hookData;
-                           
-                        $AltTextAiApiCallModel->humanGeneratedAltText = $imageResponse['alt_text'];
-                           
-                        if ($settings->useAltTextImmediately) {
-                            $asset = AssetElement::find()->id($AltTextAiApiCallModel->assetId)->one();
-                            if ($asset) {
-                                $asset->alt = $imageResponse['alt_text'];
-                                $success = Craft::$app->elements->saveElement($asset);
-                                $AltTextAiApiCallModel->altTextSyncStatus = "synced";
-                                $AltTextAiApiCallModel->humanAltTextSyncStatus = "synced";
-                                unset($asset);
-                            } else {
-                                $AltTextAiApiCallModel->altTextSyncStatus = "review";
-                                $AltTextAiApiCallModel->humanAltTextSyncStatus = "review";
-                            }
-                        } else {
-                            $AltTextAiApiCallModel->altTextSyncStatus = "review";
-                            $AltTextAiApiCallModel->humanAltTextSyncStatus = "review";
-                        }
-                           
-                           
-                        $this->saveApiCall($AltTextAiApiCallModel);
-                        unset($AltTextAiApiCallModel);
-                    }
-                }
-            }
-        }
-        
-        unset($responseArray);
-    }
-    
-    
-    
-    
-    public function getAltTextForUrl($url)
-    {
-        $callDetails = [
-            "image" => [
-                "url" => $url,
-            ],
-        ];
-        $altTextApiResponse = $this->makeCreateImageApiCall($callDetails);
-        
-        return  $altTextApiResponse;
-    }
-    
-    
-  
-    
-   
-    
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->queueAllImages($generateForNoAltText, $generateForAltText);
-    public function queueAllImages($generateForNoAltText = false , $generateForAltText = false)
-    {
-        $websiteUrl = rtrim(UrlHelper::baseSiteUrl(), "/");
-                
-        
-        
-        $currentUser = Craft::$app->getUser()->getIdentity();
-        if ($currentUser) {
-            $currentUserId = $currentUser->id;
-        } else {
-            $currentUserId = null;
-        }
-        
-        $numberOfCredits = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
-        $numberOfCredits = $numberOfCredits;
-    
-        $requestCount = 0;
-        if ($generateForNoAltText) {
-            $assetsQuery = AssetElement::find()->kind('image')->hasAlt(false);
-            $assets = $assetsQuery->all();
-            foreach ($assets as $asset) {
-                $requestCount++;
-                
-                if ($requestCount >= $numberOfCredits) {
-                    continue;
-                }
-                
-                
-                $suitability = $this->checkAssetSuitability($asset);
-                
-                if (!$suitability['success']) {
-                    continue;
-                }
-                
-                Queue::push(new RequestAltTextJob([
-                    "assetId" => $asset->id,
-                    "requestUserId" => $currentUserId,
-                    "actionType" => "Queue all",
-                ]));
-                
-                unset($suitability);
-            }
-            unset($assets);
-        }
-        
-        if ($generateForAltText) {
-            $assetsQuery = AssetElement::find()->kind('image')->hasAlt(true);
-            $assets = $assetsQuery->all();
-            foreach ($assets as $asset) {
-                $requestCount++;
-                
-                if ($requestCount >= $numberOfCredits) {
-                    continue;
-                }
-                
-                $suitability = $this->checkAssetSuitability($asset);
-                
-                if (!$suitability['success']) {
-                    continue;
-                }
-                
-                Queue::push(new RequestAltTextJob([
-                    "assetId" => $asset->id,
-                    "requestUserId" => $currentUserId,
-                    "actionType" => "Queue all",
-                ]));
-                
-                unset($suitability);
-            }
-            unset($assets);
-        }
-        
-        
-        /*
-        echo $websiteUrl ;
-        echo "\n";
-        echo "\n";
-        */
-        
-        return true;
-    }
-    
-    
-    
-    public function makeGetImageByAssetIdApiCall($asset_id)
-    {
-        $url = "https://alttext.ai/api/v1/images/" . $asset_id;
-    
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        $apiKey = $settings->apiKey;
-        $options = array(
-          'http' => array(
-            'method' => "GET",
-            'header' => "X-API-Key: " . $apiKey . "\n" .
-                      "Content-Type: application/json",
-            "ignore_errors" => true,
-          ),
-        );
-        
-        $context = stream_context_create($options);
-        $jsonResponse = file_get_contents($url, false, $context);
-        
-        return $jsonResponse;
-    }
-    
-    public function makeCreateImageApiCall($callDetailsArray)
-    {
-        $callDetailsJson = json_encode($callDetailsArray);
-        $url = "https://alttext.ai/api/v1/images";
+	public function updateAssetWithGeneratedAltText($apiCallId, $type = "generated") {
+		if (!$apiCallId) {
+			return false;
+		}
+		$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
 
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        $apiKey = $settings->apiKey;
-        $options = array(
-          'http' => array(
-            'method' => "POST",
-            'header' => "X-API-Key: " . $apiKey . "\n" .
-                      "Content-Type: application/json",
-            'content' => $callDetailsJson,
-            "ignore_errors" => true,
-          ),
-        );
-        
-        $context = stream_context_create($options);
-        $jsonResponse = file_get_contents($url, false, $context);
-        
-        return $jsonResponse;
-    }
-    
-    
-    public function requestHumanReviewApiCall($asset_id)
-    {
-        $url = "https://alttext.ai/api/v1/images/" . $asset_id . "/augment";
-    
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        $apiKey = $settings->apiKey;
-        $options = array(
-           'http' => array(
-             'method' => "POST",
-             'header' => "X-API-Key: " . $apiKey . "\n" .
-                       "Content-Type: application/json",
-             "ignore_errors" => true,
-           ),
-         );
-         
-        $context = stream_context_create($options);
-        $jsonResponse = file_get_contents($url, false, $context);
-        
-         
-        return $jsonResponse;
-    }
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->makeAccountApiCall();
-   
-    public function makeAccountApiCall()
-    {
-        $url = "https://alttext.ai/api/v1/account";
-       
-        $settings = AltTextGenerator::getInstance()->getSettings();
-        $apiKey = $settings->apiKey;
+		if (!$AltTextAiApiCallModel) {
+			return false;
+		}
 
-        if (!$apiKey) {
-            return false;
-        }
-       
-        $options = array(
-         'http' => array(
-           'method' => "GET",
-           'header' => "X-API-Key:  " . $apiKey . "\n",
-           'ignore_errors' => true
-         ),
-       );
-       
-        $context = stream_context_create($options);
-        $jsonResponse = @file_get_contents($url, false, $context);
-        if($jsonResponse )
-        {
-            return $jsonResponse;
-        }
-        else{
-            return false;
-        }
-        
-    }
+		if (!$AltTextAiApiCallModel->assetId) {
+			return false;
+		}
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		// get Asset
+		$asset = $this->getAssetAndCheck($AltTextAiApiCallModel->assetId, $AltTextAiApiCallModel->siteId);
+		if (!$asset) {
+			return false;
+		}
+
+		switch ($type) {
+			case "generated":
+
+				if ($AltTextAiApiCallModel->generatedAltText != "") {
+
+					if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+						$asset->alt = $AltTextAiApiCallModel->generatedAltText;
+					} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+						$asset->setFieldValue($settings->customField, $AltTextAiApiCallModel->generatedAltText);
+					} else {
+						$asset->alt = $AltTextAiApiCallModel->generatedAltText;
+					}
+
+					$success = Craft::$app->elements->saveElement($asset);
+					$AltTextAiApiCallModel->altTextSyncStatus = "synced";
+					$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+				}
+
+				break;
 
 
-    public function getApikeyStatus($accountJson)
-    {
-        $accountArray = json_decode($accountJson, true);
+			case "original":
+
+				if ($AltTextAiApiCallModel->originalAltText != "") {
+
+					if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+						$asset->alt = $AltTextAiApiCallModel->originalAltText;
+					} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+						$asset->setFieldValue($settings->customField, $AltTextAiApiCallModel->originalAltText);
+					} else {
+						$asset->alt = $AltTextAiApiCallModel->originalAltText;
+					}
+
+					$success = Craft::$app->elements->saveElement($asset);
+				}
+
+				break;
+
+			case "humanGenerated":
+
+				if ($AltTextAiApiCallModel->humanGeneratedAltText != "") {
+
+					if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+						$asset->alt = $AltTextAiApiCallModel->humanGeneratedAltText;
+					} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+						$asset->setFieldValue($settings->customField, $AltTextAiApiCallModel->humanGeneratedAltText);
+					} else {
+						$asset->alt = $AltTextAiApiCallModel->humanGeneratedAltText;
+					}
+					$success = Craft::$app->elements->saveElement($asset);
+					$AltTextAiApiCallModel->altTextSyncStatus = "synced";
+					$AltTextAiApiCallModel->humanGeneratedAltText = "synced";
+					$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+				}
+
+				break;
+		}
 
 
-        if ( $accountArray && array_key_exists('name',$accountArray)) {
-            Craft::$app->cache->set('altTextApiName', $accountArray['name'], 60 * 500);
-            if ( array_key_exists('subscription',$accountArray) && is_array($accountArray['subscription']) && array_key_exists('status',$accountArray['subscription']) )
-            {
-                if($accountArray['subscription']['status'] == "active"){
-                    Craft::$app->cache->set('altTextApiError', false, 60 * 500);
-                }
-                else{
-                    Craft::$app->cache->set('altTextApiError', 'API key error', 60 * 500);
-                   
-                }
-                Craft::$app->cache->set('altTextApiStatus', $accountArray['subscription']['status'], 60 * 500);
-            }
-            else{
-                Craft::$app->cache->set('altTextApiStatus', "No active subscription (Free trial or Pay as you go)", 60 * 500);
-            }
-            
-        }
-        else{
-            Craft::$app->cache->set('altTextApiError', 'API key error', 60 * 500);
-            Craft::$app->cache->set('altTextApiName', false, 60 * 500);
-            Craft::$app->cache->set('altTextApiStatus', false, 60 * 500);
-        }
 
-    }
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
-    public function getNumberOfAltTextApiCredits()
-    {
-        $creditsCacheKey = "altTextApiCreditsCount";
-        
-        // Get the cached value, but if it doesn't exist, re-do the work
-        // and store it for 60 seconds
-        $credits = Craft::$app->cache->getOrSet($creditsCacheKey, function() {
-            // Some expensive work goes in here
-            
-            return $this->refreshNumberOfAltTextApiCredits();
-        }, 60 * 10);
-        
-        return $credits;
-    }
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextsToReview();
-    public function getNumberOfAltTextsToReview()
-    {
-        $altTextNumberOfItemsToReview = Craft::$app->cache->getOrSet("altTextNumberOfItemsToReview", function() {
-            // Some expensive work goes in here
-             
-            $reviewCalls = AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
-                 'where' =>
-                 [
-                     'altTextSyncStatus' => ['review'],
-                 ],
-             ]);
-             
-            $numberOfItemsToReview = 0;
-            if (is_countable($reviewCalls)) {
-                $numberOfItemsToReview = count($reviewCalls);
-            }
-             
-            return $numberOfItemsToReview;
-        }, 60 * 5);
-         
-        return  $altTextNumberOfItemsToReview;
-    }
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextsToReview();
-    public function refreshNumberOfAltTextsToReview(): int
-    {
-        $reviewCalls = AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
-            'where' =>
-            [
-                'altTextSyncStatus' => ['review'],
-            ],
-        ]);
-        
-        $numberOfItemsToReview = 0;
-        if (is_countable($reviewCalls)) {
-            $numberOfItemsToReview = count($reviewCalls);
-        }
-        
-        Craft::$app->cache->set("altTextNumberOfItemsToReview", $numberOfItemsToReview, 60 * 60);
-        return $numberOfItemsToReview;
-    }
-    
-    
-    // AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextApiCredits();
-    public function refreshNumberOfAltTextApiCredits()
-    {
-        $accountJson = $this->makeAccountApiCall();
+		return true;
+	}
 
-        $this->getApikeyStatus($accountJson);
-        
-        $accountArray = json_decode($accountJson, true);
-        $usage = 0;
-        $usage_limit = 0;
+	// AltTextGenerator::getInstance()->altTextAiApi->getApiCalls( );
+	public function getApiCalls($criteria = null): array {
+		$recordsQuery = AltTextAiApiCallRecord::find();
 
-        if ($accountArray) {
-            if (array_key_exists('usage', $accountArray)) {
-                $usage = $accountArray['usage'];
-            }
-            
-            if (array_key_exists('usage_limit', $accountArray)) {
-                $usage_limit = $accountArray['usage_limit'];
-            }
+		if (array_key_exists('where', $criteria)) {
+			$x = 0;
 
-        }
-       
-        
-        
-        $credits = $usage_limit - $usage;
-        
-        $creditsCacheKey = "altTextApiCreditsCount";
-        
-        Craft::$app->cache->set($creditsCacheKey, $credits, 60 * 15);
-        
-        return $credits;
-    }
+			foreach ($criteria['where'] as $criteriaItem => $criteriaValue) {
+				$x++;
+				if ($x == 1) {
+					$recordsQuery->where([$criteriaItem => $criteriaValue]);
+				} else {
+					$recordsQuery->andWhere([$criteriaItem => $criteriaValue]);
+				}
+			}
+
+			$recordsQuery->andWhere(["dateDeleted" => null]);
+		}
+
+		$records = $recordsQuery->all();
+
+		$models = array();
+
+		foreach ($records as $record) {
+			$model = new AltTextAiApiCallModel($record->getAttributes());
+			$models[] = $model;
+		}
+
+		return $models;
+	}
+
+	public function getApiCallById($id): ?AltTextAiApiCallModel {
+		$record = AltTextAiApiCallRecord::findOne(['id' => $id]);
+
+		if (!$record) {
+			return null;
+		}
+
+		$model = new AltTextAiApiCallModel($record->getAttributes());
+		return $model;
+	}
+
+
+	public function getApiCallByAssetId($id, $siteId = null): ?AltTextAiApiCallModel {
+		$query = AltTextAiApiCallRecord::find()->where(['assetId' => $id]);
+
+		if ($siteId) {
+			$query->andWhere(['siteId' => $siteId]);
+		}
+
+		$record = $query->one();
+
+		if (!$record) {
+			return null;
+		}
+
+		$model = new AltTextAiApiCallModel($record->getAttributes());
+		return $model;
+	}
+
+
+	// AltTextGenerator::getInstance()->altTextAiApi->checkGetApiCallById( $id );
+	public function checkGetApiCallById($id) {
+		$model = $this->getApiCallById($id);
+
+		print_r($model);
+	}
+
+
+	public function checkAssetSuitability($asset): array {
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		// is the element type webp / png / jpg / BMP
+		if (!$asset->kind == "image") {
+			$logMessage = "Asset Id: " . $asset->id . "Not an image";
+			AltTextGenerator::info($logMessage);
+			return [
+				'error' => true,
+				'errorMessage' => "Not an image",
+				'success' => false,
+			];
+		}
+
+
+		if (!in_array(strtolower($asset->extension), ['jpg', 'gif', 'png', 'webp', 'jpeg'])) {
+			$logMessage = "Asset Id: " . $asset->id . "Not right kind of image: " . $asset->extension;
+			AltTextGenerator::info($logMessage);
+			return [
+				'error' => true,
+				'errorMessage' => "Not right kind of image: " . $asset->extension,
+				'success' => false,
+			];
+		}
+
+
+		// check if the image is less than 16mb
+
+		if (
+			($settings->useImagePreviewUrl == "never" || $settings->useImagePreviewUrl == null || $settings->useImagePreviewUrl == false)
+			&& $asset->size > 16000000
+		) {
+			$logMessage = "Asset Id: " . $asset->id . "Image file size is over 16mb ";
+			AltTextGenerator::info($logMessage);
+			return [
+				'error' => true,
+				'errorMessage' => "Image file size is over 16mb",
+				'success' => false,
+			];
+		}
+
+		// check if the image is over 50 x 50
+		if ($asset->width < 51 || $asset->height < 51) {
+			$logMessage = "Asset Id: " . $asset->id . "Image too small ";
+			AltTextGenerator::info($logMessage);
+			return [
+				'error' => true,
+				'errorMessage' => "Image needs to over 50 x 50 pixels",
+				'success' => false,
+			];
+		}
+
+
+		return [
+			'error' => false,
+			'errorMessage' => "",
+			'success' => true,
+		];
+	}
+
+
+	public function callAltTextAiHumanReviewAipi($apiCallId, $humanRequestUserId = null) {
+		// get apiCall model
+		//
+
+		$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+
+		if (!$AltTextAiApiCallModel) {
+			//echo "no model";
+			return true;
+		}
+
+		$asset = AssetElement::find()->id($AltTextAiApiCallModel->assetId)->one();
+
+		if (!$asset) {
+			$return = [
+				'error' => true,
+				'errorMessage' => "No asset",
+			];
+			return $return;
+		}
+
+		$suitability = $this->checkAssetSuitability($asset);
+
+		if (!$suitability['success']) {
+			return $suitability;
+		}
+
+		$AltTextAiApiCallModel->humanRequestUserId = $humanRequestUserId;
+		$AltTextAiApiCallModel->humanAltTextSyncStatus = "requesting";
+		$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+		$requestId = $AltTextAiApiCallModel->requestId;
+		if (!$requestId) {
+			$requestId = $AltTextAiApiCallModel->id;
+		}
+
+		$resultsJson = $this->requestHumanReviewApiCall($requestId);
+
+
+		if ($resultsJson) {
+			$AltTextAiApiCallModel->humanAltTextSyncStatus = "requested";
+			$AltTextAiApiCallModel->humanRequest = json_encode($resultsJson);
+			$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+		}
+	}
+
+
+	// AltTextGenerator::getInstance()->altTextAiApi->callAltTextAiAipi( $assetId );
+	public function callAltTextAiAipi($assetId, $requestType = "No type", $async = false, $requestUserId = false, $overwrite = false, $siteId = null) {
+
+		// see if the asset has already been called
+		// we are not allowed to recall it. so we will set it to review again
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$AltTextAiApiCallModel = $this->getApiCallByAssetId($assetId, $siteId);
+
+		if ($AltTextAiApiCallModel && $overwrite === false) {
+			$AltTextAiApiCallModel->altTextSyncStatus = "refreshing";
+			$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+			Queue::push(new RefreshImageDetailsJob([
+				"apiCallId" => $AltTextAiApiCallModel->id,
+				"humanRequestUserId" => $requestUserId,
+			]));
+			return true;
+		} elseif ($AltTextAiApiCallModel && $overwrite) {
+			//
+		} else {
+			$AltTextAiApiCallModel = new AltTextAiApiCallModel();
+		}
+
+		// Add siteId to the model
+		if (empty($AltTextAiApiCallModel->siteId) && !empty($siteId)) {
+			$AltTextAiApiCallModel->siteId = $siteId;
+		}
+
+
+		// get the element
+		$query = AssetElement::find()->id($assetId);
+		if ($AltTextAiApiCallModel->siteId) {
+			$query->siteId($AltTextAiApiCallModel->siteId);
+		}
+
+		$asset = $query->one();
+
+		if (!$asset) {
+			return [
+				'error' => true,
+				'errorMessage' => "No asset",
+			];
+		}
+
+		$suitability = $this->checkAssetSuitability($asset);
+
+		if (!$suitability['success']) {
+			return $suitability;
+		}
+
+		// check if we have enough credits
+		// if we don't have credits pause this...
+
+
+		// create an rquestId
+
+		$requestId = StringHelper::toKebabCase(Craft::$app->getSystemName()) . "_" . $asset->uid . "_" . $asset->id . "_" . $siteId;
+
+		// create a call model
+
+		if (
+			$settings->useImagePreviewUrl == "always"
+			|| ($settings->useImagePreviewUrl == "forLargeImages" && $asset->size > 10000000)
+		) {
+			// use image preview url if it's been set in settings
+			$assetUrl = Craft::$app->getAssets()->getImagePreviewUrl($asset, 2000, 2000);
+		} else {
+			$assetUrl = $asset->url;
+		}
+
+
+
+		$AltTextAiApiCallModel->assetId = $asset->id;
+		$AltTextAiApiCallModel->requestId = $requestId;
+		$AltTextAiApiCallModel->requestType = $requestType;
+		$AltTextAiApiCallModel->dateRequest = DateTimeHelper::currentUTCDateTime();
+		if ($overwrite) {
+			$AltTextAiApiCallModel->altTextSyncStatus = "recalled";
+		} else {
+			$AltTextAiApiCallModel->altTextSyncStatus = "called";
+		}
+
+
+
+		if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+			$AltTextAiApiCallModel->originalAltText = $asset->alt;
+		} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+			$AltTextAiApiCallModel->originalAltText =  $asset->getFieldValue($settings->customField);
+		} else {
+			$AltTextAiApiCallModel->originalAltText = $asset->alt;
+		}
+
+		if ($requestUserId) {
+			$AltTextAiApiCallModel->requestUserId = $requestUserId;
+		}
+
+		// do the call
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		$modelName = $settings->modelName;
+		if ($modelName == "" || $modelName == null) {
+			$modelName = "describe-regular";
+		}
+
+
+		// Get site language if siteId is provided
+		$lang = $settings->lang; // Default fallback
+		if ($siteId) {
+			$site = Craft::$app->getSites()->getSiteById($siteId);
+			if ($site) {
+				$lang = strtolower(substr($site->language, 0, 2));
+			}
+		}
+
+		$webHookParams = [
+			'securityCode' => $settings->securityCode,
+		];
+		$webhookUrl = UrlHelper::actionUrl('alt-text-generator/alt-text-ai-webhook/web-hook', $webHookParams, null, false);
+		$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+		$imageUrl = UrlHelper::siteUrl($assetUrl);
+
+		$callDetails = [
+			"image" => [
+				"url" => $imageUrl . '?lang=' . $lang,
+				"asset_id" => $AltTextAiApiCallModel->requestId,
+				"metadata" => [
+					"assetId" => $asset->id,
+					"apiCallId" => $AltTextAiApiCallModel->id,
+					"siteId" => $AltTextAiApiCallModel->siteId,
+				],
+			],
+			"model_name" => $modelName,
+			"async" => (bool) $settings->asyncApi,
+			"lang" => $lang
+		];
+
+		if ($settings->asyncApi) {
+			$callDetails['webhook_url'] = $webhookUrl;
+		}
+
+		if ($overwrite) {
+			$callDetails['overwrite'] = true;
+		}
+
+		$AltTextAiApiCallModel->request = json_encode($callDetails);
+		$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+
+		$resultsJson = $this->makeCreateImageApiCall($callDetails);
+		AltTextGenerator::info($resultsJson);
+		$AltTextAiApiCallModel->response = $resultsJson;
+		$AltTextAiApiCallModel->dateResponse = DateTimeHelper::currentUTCDateTime();
+		$AltTextAiApiCallModel->altTextSyncStatus = "received";
+		$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+
+		$resultsArray = json_decode($resultsJson, true);
+
+
+		if ($resultsArray && array_key_exists('errors', $resultsArray) && count($resultsArray['errors']) > 0) {
+			$AltTextAiApiCallModel->altTextSyncStatus = "errors";
+			$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+		} elseif (!$async && $resultsArray && array_key_exists('alt_text', $resultsArray)) {
+
+			$newAltText = $resultsArray['alt_text'];
+			$AltTextAiApiCallModel->generatedAltText = $newAltText;
+
+			if ($settings->useAltTextImmediately) {
+
+
+				if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+					$asset->alt = $newAltText;
+				} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+					$asset->setFieldValue($settings->customField, $newAltText);
+				} else {
+					$asset->alt = $newAltText;
+				}
+
+				$success = Craft::$app->elements->saveElement($asset);
+				$AltTextAiApiCallModel->altTextSyncStatus = "synced";
+			} else {
+				$AltTextAiApiCallModel->altTextSyncStatus = "review";
+			}
+
+			$AltTextAiApiCallModel = $this->saveApiCall($AltTextAiApiCallModel);
+		}
+
+
+
+
+		// what is they get a 429 error
+
+
+		// what if it already exists?
+		// then we need to update the asset straight away
+	}
+
+
+
+
+	// AltTextGenerator::getInstance()->altTextAiApi->processAltTextAiWebhook( $hookData );
+	public function processAltTextAiWebhook($hookData) {
+		// this saves the hook data to the api call hook
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		$responseArray = json_decode($hookData, true);
+
+		if ($responseArray && array_key_exists("event", $responseArray)) {
+			if ($responseArray['event'] == "uploaded") {
+				$this->processAltTextAiWebhookUploaded($hookData);
+			}
+
+			if ($responseArray['event'] == "reviewed") {
+				$this->processAltTextAiWebhookReviewed($hookData);
+			}
+		}
+		unset($hookData);
+		unset($responseArray);
+	}
+
+
+	public function processAltTextAiWebhookUploaded($hookData) {
+		$responseArray = json_decode($hookData, true);
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		if (is_array($responseArray) && array_key_exists("data", $responseArray) && array_key_exists("images", $responseArray['data'])) {
+			foreach ($responseArray['data']['images'] as $imageResponse) {
+				if (array_key_exists('asset_id',  $imageResponse)) {
+					$apiCallId = $imageResponse['asset_id'];
+					if (array_key_exists('metadata',  $imageResponse) && array_key_exists('apiCallId',  $imageResponse['metadata'])) {
+						$apiCallId = $imageResponse['metadata']['apiCallId'];
+					}
+
+					$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+
+					if ($AltTextAiApiCallModel) {
+						$AltTextAiApiCallModel->dateResponse = DateTimeHelper::currentUTCDateTime();
+						$AltTextAiApiCallModel->response = $hookData;
+
+						$AltTextAiApiCallModel->generatedAltText = $imageResponse['alt_text'];
+
+						if ($settings->useAltTextImmediately === true) {
+							$query = AssetElement::find()->id($AltTextAiApiCallModel->assetId);
+
+							if ($AltTextAiApiCallModel->siteId) {
+								$query->siteId($AltTextAiApiCallModel->siteId);
+							}
+
+							$asset = $query->one();
+
+							if ($asset) {
+
+
+								if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+									$asset->alt = $imageResponse['alt_text'];
+								} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+									$asset->setFieldValue($settings->customField, $imageResponse['alt_text']);
+								} else {
+									$asset->alt = $imageResponse['alt_text'];
+								}
+
+
+								$success = Craft::$app->elements->saveElement($asset);
+								$AltTextAiApiCallModel->altTextSyncStatus = "synced";
+
+								unset($asset);
+							} else {
+								$AltTextAiApiCallModel->altTextSyncStatus = "review";
+							}
+						} else {
+							$AltTextAiApiCallModel->altTextSyncStatus = "review";
+						}
+
+
+						$this->saveApiCall($AltTextAiApiCallModel);
+						unset($AltTextAiApiCallModel);
+					}
+				}
+			}
+		}
+
+
+		unset($responseArray);
+	}
+
+
+	public function processAltTextAiWebhookReviewed($hookData) {
+		$responseArray = json_decode($hookData, true);
+		$settings = AltTextGenerator::getInstance()->getSettings();
+
+		if (is_array($responseArray) && array_key_exists("data", $responseArray) && array_key_exists("images", $responseArray['data'])) {
+			foreach ($responseArray['data']['images'] as $imageResponse) {
+				if (array_key_exists('asset_id',  $imageResponse)) {
+					$apiCallId = $imageResponse['asset_id'];
+					if (array_key_exists('metadata',  $imageResponse) && array_key_exists('apiCallId',  $imageResponse['metadata'])) {
+						$apiCallId = $imageResponse['metadata']['apiCallId'];
+					}
+
+					$AltTextAiApiCallModel = $this->getApiCallById($apiCallId);
+
+					if ($AltTextAiApiCallModel) {
+						$AltTextAiApiCallModel->humanDateResponse = DateTimeHelper::currentUTCDateTime();
+						$AltTextAiApiCallModel->humanResponse = $hookData;
+
+						$AltTextAiApiCallModel->humanGeneratedAltText = $imageResponse['alt_text'];
+
+						if ($settings->useAltTextImmediately) {
+							$query = AssetElement::find()->id($AltTextAiApiCallModel->assetId);
+
+							if ($AltTextAiApiCallModel->siteId) {
+								$query->siteId($AltTextAiApiCallModel->siteId);
+							}
+
+							$asset = $query->one();
+
+							if ($asset) {
+
+								if (isset($settings->customField) && ($settings->customField == "alt" || $settings->customField == null)) {
+									$asset->alt = $imageResponse['alt_text'];
+								} elseif ($asset->getFieldLayout()->getFieldByHandle($settings->customField)) {
+									$asset->setFieldValue($settings->customField, $imageResponse['alt_text']);
+								} else {
+									$asset->alt = $imageResponse['alt_text'];
+								}
+
+								$success = Craft::$app->elements->saveElement($asset);
+								$AltTextAiApiCallModel->altTextSyncStatus = "synced";
+								$AltTextAiApiCallModel->humanAltTextSyncStatus = "synced";
+								unset($asset);
+							} else {
+								$AltTextAiApiCallModel->altTextSyncStatus = "review";
+								$AltTextAiApiCallModel->humanAltTextSyncStatus = "review";
+							}
+						} else {
+							$AltTextAiApiCallModel->altTextSyncStatus = "review";
+							$AltTextAiApiCallModel->humanAltTextSyncStatus = "review";
+						}
+
+
+						$this->saveApiCall($AltTextAiApiCallModel);
+						unset($AltTextAiApiCallModel);
+					}
+				}
+			}
+		}
+
+		unset($responseArray);
+	}
+
+
+
+
+	public function getAltTextForUrl($url) {
+		$callDetails = [
+			"image" => [
+				"url" => $url,
+			],
+		];
+		$altTextApiResponse = $this->makeCreateImageApiCall($callDetails);
+
+		return  $altTextApiResponse;
+	}
+
+
+
+
+
+
+
+	// AltTextGenerator::getInstance()->altTextAiApi->queueAllImages($generateForNoAltText, $generateForAltText, $overwrite);
+	public function queueAllImages($generateForNoAltText = false, $generateForAltText = false, $overwrite = false) {
+		$sites = Craft::$app->getSites()->getAllSites();
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$customField = false;
+		if (isset($settings->customField)) {
+			$customField = $settings->customField;
+		}
+
+		$currentUser = Craft::$app->getUser()->getIdentity();
+		$currentUserId = $currentUser ? $currentUser->id : null;
+
+		$queueAllReport  = new QueueAllReportModel();
+
+		$numberOfCredits = AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
+
+		$queueAllReport->numberOfCredits = $numberOfCredits;
+		$requestCount = 0;
+		$numberRejected = 0;
+		$numberRequested = 0;
+
+		if ($generateForNoAltText) {
+			if ($customField && ($settings->customField == "alt" || $settings->customField == null)) {
+				$assetsQuery = AssetElement::find()->kind('image')->hasAlt(false);
+			} else {
+				try {
+					$assetsQuery = AssetElement::find()->kind('image')->$customField(':empty:');
+				} catch (Exception $e) {
+					$assetsQuery = AssetElement::find()->kind('image')->hasAlt(false);
+				}
+			}
+
+			$assets = $assetsQuery->all();
+			$queueAllReport->numberOfAssetsWithNoAltText = count($assets);
+
+			foreach ($assets as $asset) {
+				foreach ($sites as $site) {
+					if ($requestCount >= $numberOfCredits) {
+						$numberRejected++;
+
+						$queueAllReport->numberOfAssetsRejectedWithNoAltText++;
+						$queueAllReport->assets[] = [
+							"assetId" => $asset->id,
+							"assetUrl" => $asset->url,
+							"assetTitle" => $asset->title,
+							"siteId" => $site->id,
+							"assetQueueStatus" => "Not queued due to lack of credits"
+						];
+						continue;
+					}
+
+					$suitability = $this->checkAssetSuitability($asset);
+
+					if (!$suitability['success']) {
+						$numberRejected++;
+						$queueAllReport->numberOfAssetsRejectedWithNoAltText++;
+						$queueAllReport->assets[] = [
+							"assetId" => $asset->id,
+							"assetUrl" => $asset->url,
+							"assetTitle" => $asset->title,
+							"siteId" => $site->id,
+							"assetQueueStatus" =>  $suitability['errorMessage']
+						];
+						continue;
+					}
+
+					$numberRequested++;
+
+					$queueAllReport->numberOfAssetsQueuedWithNoAltText++;
+					$queueAllReport->assets[] = [
+						"assetId" => $asset->id,
+						"assetUrl" => $asset->url,
+						"assetTitle" => $asset->title,
+						"siteId" => $site->id,
+						"assetQueueStatus" => "Queued"
+					];
+
+					Queue::push(new RequestAltTextJob([
+						"assetId" => $asset->id,
+						"requestUserId" => $currentUserId,
+						"actionType" => "Queue all",
+						"overwrite" => $overwrite,
+						"siteId" => $site->id,
+					]));
+					$requestCount++;
+				}
+				unset($suitability);
+			}
+			unset($assets);
+		}
+
+		if ($generateForAltText) {
+			if ($customField && ($settings->customField == "alt" || $settings->customField == null)) {
+				$assetsQuery = AssetElement::find()->kind('image')->hasAlt(true);
+			} else {
+				try {
+					$assetsQuery = AssetElement::find()->kind('image')->$customField(':notempty:');
+				} catch (Exception $e) {
+					$assetsQuery = AssetElement::find()->kind('image')->hasAlt(true);
+				}
+			}
+
+			$assets = $assetsQuery->all();
+			$queueAllReport->numberOfAssetsWithAltText = count($assets);
+
+			foreach ($assets as $asset) {
+				foreach ($sites as $site) {
+					if ($requestCount >= $numberOfCredits) {
+						$numberRejected++;
+						$queueAllReport->numberOfAssetsRejectedWithAltText++;
+
+						$queueAllReport->assets[] = [
+							"assetId" => $asset->id,
+							"assetUrl" => $asset->url,
+							"assetTitle" => $asset->title,
+							"siteId" => $site->id,
+							"assetQueueStatus" =>  "Not queued due to lack of credits"
+						];
+						continue;
+					}
+
+					$suitability = $this->checkAssetSuitability($asset);
+
+					if (!$suitability['success']) {
+						$numberRejected++;
+						$queueAllReport->numberOfAssetsRejectedWithAltText++;
+
+						$queueAllReport->assets[] = [
+							"assetId" => $asset->id,
+							"assetUrl" => $asset->url,
+							"assetTitle" => $asset->title,
+							"siteId" => $site->id,
+							"assetQueueStatus" =>  $suitability['errorMessage']
+						];
+						continue;
+					}
+
+					$numberRequested++;
+					$queueAllReport->numberOfAssetsQueuedWithAltText++;
+					$queueAllReport->assets[] = [
+						"assetId" => $asset->id,
+						"assetUrl" => $asset->url,
+						"assetTitle" => $asset->title,
+						"siteId" => $site->id,
+						"assetQueueStatus" => "Queued"
+					];
+
+					Queue::push(new RequestAltTextJob([
+						"assetId" => $asset->id,
+						"requestUserId" => $currentUserId,
+						"actionType" => "Queue all",
+						"overwrite" => $overwrite,
+						"siteId" => $site->id,
+					]));
+					$requestCount++;
+				}
+				unset($suitability);
+			}
+			unset($assets);
+		}
+
+		return $queueAllReport;
+	}
+
+
+
+	public function makeGetImageByAssetIdApiCall($requestId) {
+		$url = "https://alttext.ai/api/v1/images/" . $requestId;
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$apiKey = $settings->getApiKey(true);
+		$options = array(
+			'http' => array(
+				'method' => "GET",
+				'header' => "X-API-Key: " . $apiKey . "\n" .
+					"Content-Type: application/json",
+				"ignore_errors" => true,
+			),
+		);
+
+		$context = stream_context_create($options);
+		$jsonResponse = file_get_contents($url, false, $context);
+
+		return $jsonResponse;
+	}
+
+	public function makeCreateImageApiCall($callDetailsArray) {
+		$callDetailsJson = json_encode($callDetailsArray);
+		$url = "https://alttext.ai/api/v1/images";
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$apiKey = $settings->getApiKey(true);
+		$options = array(
+			'http' => array(
+				'method' => "POST",
+				'header' => "X-API-Key: " . $apiKey . "\n" .
+					"Content-Type: application/json",
+				'content' => $callDetailsJson,
+				"ignore_errors" => true,
+			),
+		);
+
+		$context = stream_context_create($options);
+		$jsonResponse = @file_get_contents($url, false, $context);
+
+		// Check if response is false (indicating an error)
+		if ($jsonResponse === false) {
+			// Parse the HTTP response headers to get the status code
+			if (isset($http_response_header)) {
+				// Extract the HTTP status code from the response headers
+				$status_line = $http_response_header[0];
+				$jsonResponse = '{"errors": "' . $status_line . '" }';
+			} else {
+				$jsonResponse = '{"errors":"HTTP request failed: No headers returned." }';
+			}
+		}
+
+		return $jsonResponse;
+	}
+
+
+	public function requestHumanReviewApiCall($asset_id) {
+		$url = "https://alttext.ai/api/v1/images/" . $asset_id . "/augment";
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$apiKey = $settings->getApiKey(true);
+		$options = array(
+			'http' => array(
+				'method' => "POST",
+				'header' => "X-API-Key: " . $apiKey . "\n" .
+					"Content-Type: application/json",
+				"ignore_errors" => true,
+			),
+		);
+
+		$context = stream_context_create($options);
+		$jsonResponse = file_get_contents($url, false, $context);
+
+
+		return $jsonResponse;
+	}
+
+	// AltTextGenerator::getInstance()->altTextAiApi->makeAccountApiCall();
+
+	public function makeAccountApiCall() {
+		$url = "https://alttext.ai/api/v1/account";
+
+		$settings = AltTextGenerator::getInstance()->getSettings();
+		$apiKey = $settings->getApiKey(true);
+
+		if (!$apiKey) {
+			return false;
+		}
+
+		$options = array(
+			'http' => array(
+				'method' => "GET",
+				'header' => "X-API-Key:  " . $apiKey . "\n",
+				'ignore_errors' => true
+			),
+		);
+
+		$context = stream_context_create($options);
+		$jsonResponse = @file_get_contents($url, false, $context);
+		if ($jsonResponse) {
+			return $jsonResponse;
+		} else {
+			return false;
+		}
+	}
+
+
+	public function getApikeyStatus($accountJson) {
+		$accountArray = json_decode($accountJson, true);
+
+
+		if ($accountArray && array_key_exists('name', $accountArray)) {
+			Craft::$app->cache->set('altTextApiName', $accountArray['name'], 60 * 500);
+			if (array_key_exists('subscription', $accountArray) && is_array($accountArray['subscription']) && array_key_exists('status', $accountArray['subscription'])) {
+				if ($accountArray['subscription']['status'] == "active") {
+					Craft::$app->cache->set('altTextApiError', false, 60 * 500);
+				} else {
+					Craft::$app->cache->set('altTextApiError', 'API key error', 60 * 500);
+				}
+				Craft::$app->cache->set('altTextApiStatus', $accountArray['subscription']['status'], 60 * 500);
+			} else {
+				Craft::$app->cache->set('altTextApiStatus', "No active subscription (Free trial or Pay as you go)", 60 * 500);
+			}
+		} else {
+			Craft::$app->cache->set('altTextApiError', 'API key error', 60 * 500);
+			Craft::$app->cache->set('altTextApiName', false, 60 * 500);
+			Craft::$app->cache->set('altTextApiStatus', false, 60 * 500);
+		}
+	}
+
+	// AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextApiCredits();
+	public function getNumberOfAltTextApiCredits() {
+		$creditsCacheKey = "altTextApiCreditsCount";
+
+		// Get the cached value, but if it doesn't exist, re-do the work
+		// and store it for 60 seconds
+		$credits = Craft::$app->cache->getOrSet($creditsCacheKey, function () {
+			// Some expensive work goes in here
+
+			return $this->refreshNumberOfAltTextApiCredits();
+		}, 60 * 10);
+
+		return $credits;
+	}
+
+	// AltTextGenerator::getInstance()->altTextAiApi->getNumberOfAltTextsToReview();
+	public function getNumberOfAltTextsToReview() {
+		$altTextNumberOfItemsToReview = Craft::$app->cache->getOrSet("altTextNumberOfItemsToReview", function () {
+			// Some expensive work goes in here
+
+			$reviewCalls = AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
+				'where' =>
+				[
+					'altTextSyncStatus' => ['review'],
+				],
+			]);
+
+			$numberOfItemsToReview = 0;
+			if (is_countable($reviewCalls)) {
+				$numberOfItemsToReview = count($reviewCalls);
+			}
+
+			return $numberOfItemsToReview;
+		}, 60 * 5);
+
+		return  $altTextNumberOfItemsToReview;
+	}
+
+	// AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextsToReview();
+	public function refreshNumberOfAltTextsToReview(): int {
+		$reviewCalls = AltTextGenerator::getInstance()->altTextAiApi->getApiCalls([
+			'where' =>
+			[
+				'altTextSyncStatus' => ['review'],
+			],
+		]);
+
+		$numberOfItemsToReview = 0;
+		if (is_countable($reviewCalls)) {
+			$numberOfItemsToReview = count($reviewCalls);
+		}
+
+		Craft::$app->cache->set("altTextNumberOfItemsToReview", $numberOfItemsToReview, 60 * 60);
+		return $numberOfItemsToReview;
+	}
+
+
+	// AltTextGenerator::getInstance()->altTextAiApi->refreshNumberOfAltTextApiCredits();
+	public function refreshNumberOfAltTextApiCredits() {
+		$accountJson = $this->makeAccountApiCall();
+
+		$this->getApikeyStatus($accountJson);
+
+		$accountArray = json_decode($accountJson, true);
+		$usage = 0;
+		$usage_limit = 0;
+
+		if ($accountArray) {
+			if (array_key_exists('usage', $accountArray)) {
+				$usage = $accountArray['usage'];
+			}
+
+			if (array_key_exists('usage_limit', $accountArray)) {
+				$usage_limit = $accountArray['usage_limit'];
+			}
+		}
+
+
+
+		$credits = $usage_limit - $usage;
+
+		$creditsCacheKey = "altTextApiCreditsCount";
+
+		Craft::$app->cache->set($creditsCacheKey, $credits, 60 * 15);
+
+		return $credits;
+	}
 }


### PR DESCRIPTION
With the custom field that has been added to the project, I added couple changes on how to handle the language sent to the AltText.ai. Instead of using the language selected in the configuration, it uses the language set for the current site in the CP and it saves back the response in the proper asset language.

I also added a button directly inside the Asset Page instead of using the action in the asset list page.

I needed to adjust that for my current use of this plugin on a multilingual site. This is basically an idea of how to use the siteId that is already saved inside the DB table.